### PR TITLE
Support live JSON-Schema pull

### DIFF
--- a/resources/docker-neoload-cli/Dockerfile
+++ b/resources/docker-neoload-cli/Dockerfile
@@ -6,6 +6,10 @@ RUN \
 # Check for mandatory build arguments
     : "${PYPI_VERSION:?Build argument needs to be set and non-empty.}"
 
+# add GCC deps, Python, and NeoLoad
 RUN apk add -q gcc musl-dev && \
     python3 -m pip install -q --upgrade pip && \
-    python3 -m pip install -q neoload==$PYPI_VERSION
+    python3 -m pip install --index-url https://test.pypi.org/simple/ \
+                           --upgrade --no-cache-dir -q \
+                           --extra-index-url=https://pypi.org/simple/ \
+                           neoload==$PYPI_VERSION

--- a/resources/docker-neoload-cli/Dockerfile-dev
+++ b/resources/docker-neoload-cli/Dockerfile-dev
@@ -1,23 +1,24 @@
 FROM python:3.7-alpine
 
-##RUN apk add -q bash shadow git py-pip py3-setuptools build-base python3-dev \
-#RUN apk add -q build-base
-#RUN ls -latr /usr/libexec/gcc/x86_64-alpine-linux-musl/9.2.0/
-#RUN rm -rf $(find /usr/libexec/gcc/x86_64-alpine-linux-musl/ -name "cc1obj") && \
-#    rm -rf $(find /usr/libexec/gcc/x86_64-alpine-linux-musl/ -name "lto*") && \
-#    rm -rf /usr/bin/x86_64-alpine-linux-musl-gcj
-#RUN ls -latr /usr/libexec/gcc/x86_64-alpine-linux-musl/9.2.0/
-RUN apk add gcc musl-dev
-RUN python3 -m pip install -q --upgrade pip
+# add GCC deps, Python (NeoLoad in dev comes later)
+RUN apk add -q gcc musl-dev && \
+    python3 -m pip install -q --upgrade pip
 
-# this would be used in production-ready images
-#RUN python3 -m pip install -q neoload
+
+# for use in CI with a build agent that is a docker host (or connected to one)
+ENV DOCKERVERSION=18.03.1-ce
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
+ && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
+                -C /usr/local/bin docker/docker \
+ && rm docker-${DOCKERVERSION}.tgz
+
+# copy in current codebase and install CLI
+COPY ./ /python_root
+RUN rm -rf /python_root/tests /python_root/pipeline_examples && \
+    rm -rf /python_root/dist /python_root/build /python_root/.git/python_root/.git*
+RUN python3 -m pip install -q -e /python_root
 
 ## for local dev purposes only
 #$ docker build -t neoload-cli-dev --file resources/docker-neoload-cli/Dockerfile-dev .
 #$ docker run --rm neoload-cli-dev neoload --version
 #$ docker rmi neoload-cli-dev
-COPY ./ /python_root
-RUN rm -rf /python_root/tests /python_root/pipeline_examples && \
-    rm -rf /python_root/dist /python_root/build /python_root/.git/python_root/.git*
-RUN python3 -m pip install -q -e /python_root

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='neoload',
-      version='0.3.6',
+      version='0.3.8',
       description='A command-line native utility for launching and observing NeoLoad performance tests',
       url='https://github.com/Neotys-Labs/neoload-cli',
       author='Paul Bruce',

--- a/tests/docker/dind-python3/Dockerfile
+++ b/tests/docker/dind-python3/Dockerfile
@@ -6,17 +6,17 @@ RUN \
 # Check for mandatory build arguments
     : "${PYPI_VERSION:?Build argument needs to be set and non-empty.}"
 
+# add GCC deps, Python, and NeoLoad (to ensure installation from PyPi)
 RUN apk add -q gcc musl-dev python3-dev curl && \
     python3 -m pip install -q --upgrade pip && \
     python3 -m pip install -q neoload==$PYPI_VERSION
 
-
+# ADD DOCKER
 # for use in CI with a build agent that is a docker host (or connected to one)
-
 ENV DOCKERVERSION=18.03.1-ce
 RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
-  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
-                 -C /usr/local/bin docker/docker \
-  && rm docker-${DOCKERVERSION}.tgz
+ && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
+                -C /usr/local/bin docker/docker \
+ && rm docker-${DOCKERVERSION}.tgz
 
 RUN apk add -q bash shadow git


### PR DESCRIPTION
For Python installs where resources are not distributed to relative directory, pull schema from public repo (master branch). Fallback semantics: check relative file, GET from online, otherwise allow for JSON Schema validation bypass (will just take longer at controller).