### PR TITLE
Fix logs url when the frontend url is not on the root of the url

### DIFF
--- a/neoload/commands/logs_url.py
+++ b/neoload/commands/logs_url.py
@@ -20,4 +20,4 @@ def get_url(name: str):
 
 def get_endpoint(name: str):
     __id = tools.get_id(name, test_results.__resolver)
-    return '/#!result/%s/overview' % __id
+    return '#!result/%s/overview' % __id


### PR DESCRIPTION
Example: http://neotys.com/frontend