### PR TITLE
Topic docker cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ addons:
     token:
       secure: "HpxoA5oSxy193R40tDKbNPvhW29SYjTq2ZqgSndRqi8sdpqq1sTi5wKNeCFHK3HZnzXZffhbaHKLBut4ng92aWX8V4zKwxuLb+2tl3dL8k6H9ZI/sH61qOK83iDODDfRhic7l/al6O1YJVBXtPEwrlLvfOX0wPH/VbZQ9Vk8mJGAQrKZXeYBRsvIEs8RSajMCL0E/Di8XCCHoAXNrQjJ7k1+RCKX4jdNRYRSgdvUBic18RjffIxEZwPxSrE7L7i3KLMZj+WmaiUgPvLR6SDdtXUVJoBOxvQMmAnIQMUxeSMJ38cqlzQeWjbNoWUnLZtPuEW/Gi/vNBKvmLvS8AcpU0fhsbJ7Z32FWCP3Tdua00NMpvc9gWzl7xR6PTVR5pF2tVWW1RzhpdFYXCGr77mGCzy9/Rcp74+MKOfA8bfQQLmveAXIUk2YR9048UBJReyHuiwot3lRt7eeWxHRyDpORxy8j5siYoNfEwutdVPQqyqRjflpiOg3K3I0dtE75vuYQwdGQWY4Omgu+m+OmKXsv9thdSIEWDVC+QnMFUgnU8W8QHOdwhvg8M3FZPazDeQ569SSbG7L/MCNT6e0Zf3Pw9QUoiuJ3eqib107ZPl9VKTeIcQMJ8VsL8c7OOPY9xaIXyVzmMeLW/RPBTQ4J4dp3/u0BXj+5t6qw6p0BW/GNyE="
 
+services:
+  - docker
+  
+before_install:
+- docker pull neotys/neoload-controller:latest
+- docker pull neotys/neoload-loadgenerator:latest
 
 python:
   - "3.6"
@@ -14,7 +20,7 @@ install:
   - pip install coverage
 # command to run tests
 script:
-  - PYTHONPATH="neoload" coverage3 run -m pytest
+  - PYTHONPATH="neoload" coverage3 run -m pytest -x --integration
   - coverage3 xml
   - sonar-scanner
 deploy:

--- a/examples/pipelines/jenkins/Jenkinsfile_docker
+++ b/examples/pipelines/jenkins/Jenkinsfile_docker
@@ -1,0 +1,66 @@
+pipeline {
+  agent none
+
+  parameters {
+    string(defaultValue: "specify_token_or_get_it_from_credentials", description: 'Neoload Web Token', name: 'token')
+    string(defaultValue: "defaultzone", description: 'Zone identifier', name: 'zone_id')
+    string(defaultValue: "https://neoload-api.saas.neotys.com/", description: 'NeoLoad Web Api Url', name: 'api_url')
+  }
+
+  stages {
+    stage('Attach Worker') {
+      agent {
+        docker {
+          image 'python:3-alpine'
+        }
+      }
+      stages {
+        stage('Get NeoLoad CLI') {
+          steps {
+            withEnv(["HOME=${env.WORKSPACE}"]) {
+              sh "pip3 install ."
+              sh "python3 neoload --version"
+            }
+          }
+        }
+        stage('Prepare Neoload test') {
+          steps {
+            withEnv(["HOME=${env.WORKSPACE}"]) {
+              sh """python3 neoload \
+                     login --url ${params.api_url} ${params.token} \
+                     test-settings --zone ${params.zone_id} --scenario sanityScenario patch "My Jenkins Test With CLI" \
+                     project --path tests/neoload_projects/example_1/ upload "My Jenkins Test With CLI"
+                """
+            }
+          }
+        }
+        stage('Run Test') {
+          steps {
+            withEnv(["HOME=${env.WORKSPACE}"]) {
+              sh """python3 neoload \
+                  docker prepare
+                  run \
+                  --return-0 \
+                  --web-vu 5 \
+                  --as-code default.yaml,slas/uat.yaml \
+                  "My Jenkins Test With CLI" \
+                 """
+            }
+          }
+        }
+        stage('Generate Test Report') {
+          steps {
+            withEnv(["HOME=${env.WORKSPACE}"]) {
+                sh "python3 neoload test-results junitsla"
+            }
+          }
+          post {
+              always {
+                  junit 'junit-sla.xml'
+              }
+          }
+        }
+      }
+    }
+  }
+}

--- a/neoload/commands/docker.py
+++ b/neoload/commands/docker.py
@@ -1,0 +1,713 @@
+import sys
+import click
+
+from neoload_cli_lib import user_data, tools
+from commands import test_settings
+from neoload_cli_lib.tools import upgrade_logging,downgrade_logging
+
+import docker
+import random
+import traceback
+import platform
+from datetime import datetime
+import time
+import logging
+import json
+import socket
+from urllib.parse import urlparse
+
+
+key_container_naming_prefix = "neoload_cli"
+auto_remove_containers = True
+max_container_readiness_wait_sec = 60
+
+key_meta_prior_docker = 'prior_docker'
+key_spun_at_run = 'spun_at_run'
+key_docker_run_id = 'run_id'
+
+
+@click.command()
+@click.argument("command", required=True, type=click.Choice(['prepare','attach', 'detach', 'forget', 'verify']))
+@click.option('--tag', default="latest", help="The docker image version to use")
+@click.option('--ctrlimage', default="neotys/neoload-controller", help="The controller image to use")
+@click.option('--lgimage', default="neotys/neoload-loadgenerator", help="The load generator image to use")
+@click.option('--all', is_flag=True, help="Apply this action to all resources")
+@click.option('--nowait', is_flag=True, help="Do not wait for controller andxf load generator logs to indicate attach success")
+@click.option('--addhosts', default=None, help="Hosts to add to the /etc/hosts file of the containers")
+def cli(command, tag, ctrlimage, lgimage, all, nowait, addhosts):
+    """Use local Docker to BYO infrastructure for a test.
+    This uses the local Docker daemon to spin up containers to be used as infrastucture for the current test.
+    NOTE: this feature is not supported by NeoLoad since your own Docker configuration is out-of-scope for support."""
+
+    if command == "prepare":
+        check_docker_system()
+
+        set_prior_docker_attributes(tag,ctrlimage,lgimage,addhosts)
+
+    elif command == "attach":
+        check_docker_system()
+
+        if test_settings.is_current_test_settings_set():
+            upgrade_logging()
+            derived = derive_docker_attributes(tag,ctrlimage,lgimage,addhosts)
+            attach(explicit=True,
+                tag=derived['tag'], ctrlimage=derived['ctrlimage'], lgimage=derived['lgimage'], addhosts=derived['addhosts'],
+                wait_for_readiness=(not nowait))
+            downgrade_logging()
+        else:
+            tools.system_exit({'message': 'No current test settings set. Please login and select a test before attaching.', 'code': 3})
+
+    elif command == "detach":
+        check_docker_system()
+        upgrade_logging()
+        askmode = sys.stdin.isatty()
+        detach_infra(explicit=askmode, all=all)
+        downgrade_logging()
+
+    elif command == "forget":
+        if has_prior_attach():
+            detach_infra(explicit=False, all=True)
+        user_data.set_meta(key_meta_prior_docker,None)
+
+    elif command == "verify":
+        check_docker_system()
+        print_docker_system_status()
+
+def check_docker_system():
+    result = try_docker_system()
+
+    if not result['success']:
+        if 'connection refused' in result['logs'].lower():
+            msg = "Docker installed, but connection to dockerd failed."
+        else:
+            msg = "Docker-specific error: " + result['logs']
+
+        tools.system_exit({'message': msg, 'code': 2})
+
+def print_docker_system_status():
+    upgrade_logging()
+    try:
+        client = docker.from_env()
+        infos = client.info()
+
+        logging.debug(json.dumps(infos, indent=1))
+
+    except Exception:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        logging.error("Unexpected error from 'print_docker_system_status': "  + repr(traceback.format_exception(exc_type, exc_value,
+                                          exc_traceback)))
+    downgrade_logging()
+
+def try_docker_system():
+    result = {
+        'success': False,
+        'logs': "",
+        'nopermission': False
+    }
+    preempt_msg = "Unexpected error in 'try_docker_system':"
+    try:
+        client = docker.from_env()
+        preempt_msg = "Could not ping the Docker host."
+        client.ping()
+
+        preempt_msg = "Could not obtain version info from the Docker host."
+        client.version()
+
+        preempt_msg = "Could not list containers on the Docker host."
+        client.containers.list()
+
+        result['success'] = True
+
+    except Exception:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        full_msg = preempt_msg  + repr(traceback.format_exception(exc_type, exc_value,
+                                          exc_traceback))
+        if 'connectionerror' in full_msg.lower() and 'permission denied' in full_msg.lower():
+            result['nopermission'] = True
+            result['logs'] = preempt_msg + " Do you have rights (i.e. sudo first)?"
+        else:
+            result['logs'] = full_msg
+
+    return result
+
+
+def has_prior_attach():
+    prior = user_data.get_meta(key_meta_prior_docker)
+    return (prior is not None)
+
+
+
+def is_prior_attach_running(run_id):
+    try:
+        client = docker.from_env()
+        filters = {
+            'label': 'neoload-cli=' + run_id
+        }
+        networks = client.networks.list(
+            filters = filters,
+        )
+        return len(networks) > 0
+    except Exception:
+        return False
+
+
+
+def resume_prior_attach():
+    prior = user_data.get_meta(key_meta_prior_docker)
+    if has_prior_attach() and not (key_docker_run_id in prior and is_prior_attach_running(prior[key_docker_run_id])):
+        # if no permissions to docker, don't bother trying, warn
+        trial = try_docker_system()
+        if trial['nopermission']:
+            return False
+
+        upgrade_logging()
+        logging.info("Attaching based on prior Docker attach...")
+        prior[key_spun_at_run] = True
+        user_data.set_meta(key_meta_prior_docker, prior)
+        attach(explicit=False,
+            tag=prior['tag'], ctrlimage=prior['ctrlimage'], lgimage=prior['lgimage'], addhosts=prior['addhosts'],
+            wait_for_readiness=True)
+        downgrade_logging()
+        return True
+
+    return False
+
+
+def cleanup_after_test():
+    prior = user_data.get_meta(key_meta_prior_docker)
+    logging.debug("has_prior_attach() = " + str(has_prior_attach()))
+    if has_prior_attach() and (prior is not None and key_spun_at_run in prior and prior[key_spun_at_run] == True):
+        logging.info("Detatching after spun at run")
+        detach_infra(explicit=False, all=False)
+        downgrade_logging()
+
+
+
+def attach(explicit, tag, ctrlimage, lgimage, addhosts, wait_for_readiness):
+    is_ready = False
+
+    client = docker.from_env()
+
+    json = test_settings.get_current_test_settings_json()
+
+    container_ids = []
+    lg_container_ids = []
+    ctrl_container_id = None
+    network_id = None
+
+    run_id = str(random.randint(1,65535))
+    port_range_start = random.randint(171,471)*100 # between 17100 and 47100
+    rand_subnet_dot_two = random.randint(50,250)
+
+    network_name = key_container_naming_prefix + run_id + "_network"
+    subnet_first_three = "172."+str(rand_subnet_dot_two)+".0"
+
+    labelsall = {
+        'neoload-cli': run_id
+    }
+
+    commonenv = {
+        "NEOLOADWEB_URL": user_data.get_user_data().get_url(),
+        "NEOLOADWEB_TOKEN": user_data.get_user_data().get_token()
+    }
+
+    volumes = {}
+    #TODO (if interactive mode and in debub mode at the same time)    volumes[os.getcwd()] = {'bind': '/launch', 'mode': 'ro'}
+
+    core_constructs = {
+        'docker': client,
+        'network_name': network_name,
+        'labelsall': labelsall,
+        'volumes': volumes,
+        'run_id': run_id,
+        'commonenv': commonenv,
+        'addhosts': addhosts
+    }
+
+    try:
+        #TODO: add check if images don't exist locally yet, and pull along with proper logging.info() notifications
+        pull_if_needed(lgimage,tag)
+        pull_if_needed(ctrlimage,tag)
+
+        network = setup_network(core_constructs, subnet_first_three)
+
+        network_id = network.id
+
+        base_ipx = 2
+        lgs_spec = json['lgZoneIds']
+        lg_index = 0
+        for zone in lgs_spec:
+            num_of_lgs = lgs_spec[zone]
+
+            for x in range(num_of_lgs):
+                lg = setup_lg(core_constructs, zone, lg_index, subnet_first_three, base_ipx, port_range_start, lgimage+":"+tag)
+
+                container_ids.append(lg.id)
+                lg_container_ids.append(lg.id)
+                logging.info("Created load generator " + str(lg_index+1) + ".")
+
+                network.connect(
+                    container=lg.id,
+                    ipv4_address=lg.name # always name the container the IP address (resolve cross-platform Docker DNS issues)
+                )
+                logging.info("Attached load generator " + str(x+1) + " to network.")
+
+                base_ipx += 1
+
+                lg_index += 1
+
+
+        ctrl = setup_ctrl(core_constructs, json['controllerZoneId'], ctrlimage+":"+tag)
+        container_ids.append(ctrl.id)
+        ctrl_container_id = ctrl.id
+
+        waiting_success = False
+
+        logging.info("wait_for_readiness: " + str(wait_for_readiness))
+
+        if wait_for_readiness:
+            logging.info("Waiting for docker containers to be attached and ready.")
+
+            waiting_success = wait_for_all_containers(ctrl_container_id,lg_container_ids)
+
+            time.sleep( 1 ) # give a few moments for platform to recognize resources as available
+        else:
+            time.sleep( 1 ) # give a few moments for platform to recognize resources as available
+            waiting_success = True
+
+        if waiting_success:
+            logging.info("All containers are attached" + (" and ready for use" if wait_for_readiness else "") + ".")
+        else:
+            tools.system_exit({'message': 'Could not verify that Docker containers were ready and attached.', 'code': 2})
+
+        prior = set_prior_docker_attributes(tag,ctrlimage,lgimage,addhosts)
+
+        prior[key_docker_run_id] = run_id
+        prior[key_spun_at_run] = not explicit
+        user_data.set_meta(key_meta_prior_docker, prior)
+
+        is_ready = True
+
+    except Exception:
+        logging.error("Unexpected error in 'attach':", sys.exc_info()[0])
+
+    prior = {
+        "is_ready": is_ready,
+        "network_id": network_id
+    }
+    prior[key_docker_run_id] = run_id
+
+def create_default_docker_attributes(tag,ctrlimage,lgimage,addhosts):
+    datas = {
+        "tag": "latest" if tag is None else tag,
+        "ctrlimage": "neotys/neoload-controller" if ctrlimage is None else ctrlimage,
+        "lgimage": "neotys/neoload-loadgenerator" if lgimage is None else lgimage,
+        "addhosts": addhosts
+    }
+    return datas
+
+def derive_docker_attributes(tag,ctrlimage,lgimage,addhosts):
+    datas = create_default_docker_attributes(tag,ctrlimage,lgimage,addhosts)
+
+    prior = user_data.get_meta(key_meta_prior_docker)
+    if prior is None:
+        return datas
+
+    for key in datas:
+        if key in prior and prior[key] is not None:
+            datas[key] = prior[key]
+    return datas
+
+def set_prior_docker_attributes(tag,ctrlimage,lgimage,addhosts):
+    current = create_default_docker_attributes(tag,ctrlimage,lgimage,addhosts)
+    user_data.set_meta(key_meta_prior_docker, current)
+    return current
+
+def pull_if_needed(image_name, tag):
+    full_spec = image_name + ":" + tag
+
+    logging.info("Checking for image [" + full_spec + "]")
+    client = docker.from_env()
+
+    local_image_id = None
+
+    try:
+        image = client.images.get(full_spec)
+        local_image_id = image.short_id
+        logging.info("Using local image [" + full_spec + "]")
+    except docker.errors.ImageNotFound:
+        local_image_id = None
+
+    if local_image_id is None:
+        logging.info("Pulling [" + full_spec + "]")
+        #run_command("docker pull " + full_spec)
+        image = client.images.pull(image_name, tag)
+        image = client.images.get(full_spec)
+        local_image_id = image.short_id
+
+    logging.info("Satisfied need for image [" + full_spec + "]")
+
+
+
+# def run_command(command):
+#     cmd = ['ls', '-l', '/']
+#     proc = subprocess.Popen(
+#         shlex.split(command),
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.STDOUT,
+#         # Make all end-of-lines '\n'
+#         universal_newlines=True,
+#     )
+#     for line in unbuffered(proc):
+#         print(line)
+#
+#     rc = proc.poll()
+#     return rc
+#
+# # Unix, Windows and old Macintosh end-of-line
+# newlines = ['\n', '\r\n', '\r']
+# def unbuffered(proc, stream='stdout'):
+#     stream = getattr(proc, stream)
+#     with contextlib.closing(stream):
+#         while True:
+#             out = []
+#             last = stream.read(1)
+#             # Don't loop forever
+#             if last == '' and proc.poll() is not None:
+#                 break
+#             while last not in newlines:
+#                 # Don't loop forever
+#                 if last == '' and proc.poll() is not None:
+#                     break
+#                 out.append(last)
+#                 last = stream.read(1)
+#             out = ''.join(out)
+#             yield out
+
+def setup_network(core_constructs, subnet_first_three):
+    network = core_constructs['docker'].networks.create(
+        name = core_constructs['network_name'],
+        driver = "bridge",
+        attachable = True,
+        labels = core_constructs['labelsall'],
+        ipam = docker.types.IPAMConfig(
+            driver = 'default',
+            pool_configs=[docker.types.IPAMPool(
+                subnet = subnet_first_three+'.0/16',
+                iprange = subnet_first_three+'.0/24',
+                gateway = subnet_first_three+'.254'
+            )]
+        )
+    )
+    logging.info("Created docker network '" + core_constructs['network_name'] + "'")
+    logging.debug(network.attrs)
+    return network
+
+
+def setup_lg(core_constructs, zone, lg_index, subnet_first_three, base_ipx, port_range_start, lgimage):
+
+    lgport = port_range_start+lg_index
+    lghost = subnet_first_three+"."+str(base_ipx)
+
+    lg2ctrl_port = lgport
+    # some Docker environments (like Windows vs. linux/mac) map ports differently
+    # apparently on Windows systems, you must map to the dynamic port
+    # whereas on linux/Mac, you would route to the default port
+    if platform.system().lower() != 'windows':
+        lg2ctrl_port = 7100
+
+    hostandport = {
+        "LG_HOST": lghost,
+        "LG_PORT": lg2ctrl_port,
+        "AGENT_SERVER_PORT": lg2ctrl_port
+    }
+    lgenv = core_constructs['commonenv'].copy()
+    lgenv.update(hostandport)
+    lgenv["ZONE"] = zone
+
+    logging.info("Attaching load generator " + str(lg_index+1) + " '" + lgimage + "'.")
+
+    portspec = {}
+    portspec[""+str(lgport)+"/tcp"] = lgport
+
+    container = core_constructs['docker'].containers.run(
+        image=lgimage,
+        name = lghost,
+        labels = core_constructs['labelsall'],
+        detach=True,
+        extra_hosts=parse_extra_hosts(core_constructs['addhosts']),
+        auto_remove=auto_remove_containers,
+        environment=lgenv,
+        volumes=core_constructs['volumes'],
+        ports=portspec,
+    )
+    logging.info("Attaced load generator successfully.")
+    return container
+
+
+def setup_ctrl(core_constructs, zone, ctrlimage):
+
+    ctrlenv = {
+        "MODE": "Managed",
+        "LEASE_SERVER": "NLWEB",
+    }
+    ctrlenv.update(core_constructs['commonenv'])
+    ctrlenv["ZONE"] = zone
+
+    logging.info("Attaching controller '" + ctrlimage + "'.")
+
+    container = core_constructs['docker'].containers.run(
+        image=ctrlimage,
+        name = key_container_naming_prefix + core_constructs['run_id'] + "_ctrl",
+        network = core_constructs['network_name'],
+        labels = core_constructs['labelsall'],
+        detach=True,
+        extra_hosts=parse_extra_hosts(core_constructs['addhosts']),
+        auto_remove=auto_remove_containers,
+        environment=ctrlenv,
+        volumes=core_constructs['volumes']
+    )
+    logging.info("Attaced controller successfully.")
+    return container
+
+def parse_extra_hosts(hosts_spec):
+    dict = get_default_hosts_dns()
+    logging.debug(json.dumps(dict))
+
+    if not (hosts_spec is not None and len((hosts_spec+"").strip()) > 0):
+        return dict
+
+    hosts = hosts_spec.split(';')
+    for host_pair in hosts:
+        host_parts = host_pair.split('=')
+        ip = None
+        host = host_parts[0]
+        if len(host_parts)==1:
+            if host == 'null':
+                continue
+            logging.info("Resolving host [" + host + "]")
+            ip = socket.gethostbyname(host)
+        else:
+            ip = host_parts[1]
+        dict[host] = ip
+
+    if len(dict)>0:
+        logging.info("Added hosts: " + json.dumps(dict, indent=1))
+
+    return dict
+
+def get_default_hosts_dns():
+    dict = {}
+    urls = []
+    urls.append(user_data.get_user_data().get_url())
+    urls.append(user_data.get_user_data().get_file_storage_url())
+    urls.append(user_data.get_user_data().get_frontend_url())
+    for url in urls:
+        parsed = urlparse(url)
+        host = parsed.hostname
+        if not validate_ip(host):
+            logging.info("Resolving host [" + host + "] from URL: " + url)
+            dict[host] = socket.gethostbyname(host)
+
+    return dict
+
+
+def validate_ip(s):
+    a = s.split('.')
+    if len(a) != 4:
+        return False
+    for x in a:
+        if not x.isdigit():
+            return False
+        i = int(x)
+        if i < 0 or i > 255:
+            return False
+    return True
+
+
+def wait_for_all_containers(ctrl_container_id,lg_container_ids):
+    waiting_success = False
+
+    for container_id in lg_container_ids:
+        waiting_success = wait_for_logs_to_include(container_id,
+            "Agent started|Connection test to Neoload Web successful",
+            "Connection test to NeoLoad Web failed|The provided zone identifier is not valid")
+        if not waiting_success:
+            logging.warning("Couldn't ensure load generator readiness for " + container_id)
+            break
+
+    if ctrl_container_id is not None:
+        waiting_success = wait_for_logs_to_include(ctrl_container_id,
+            "Successfully connected to URL",
+            "Connection test to NeoLoad Web failed|The provided zone identifier is not valid")
+        if not waiting_success:
+            logging.warning("Couldn't ensure controller readiness for " + container_id)
+
+    return waiting_success
+
+def wait_for_logs_to_include(container_id, str_to_find, str_to_fail):
+    client = docker.from_env()
+    wait_sec = 0
+    started_at = datetime.now()
+    strs_to_find = str_to_find.split("|")
+    strs_to_fail = str_to_fail.split("|")
+    logstr = ""
+    found_failure = False
+    has_exception = False
+    looped_once = False
+
+    try:
+        container = client.containers.get(container_id)
+        logging.info("Waiting for container " + container.name + " logs to indicate attachment readiness")
+
+        while wait_sec < max_container_readiness_wait_sec:
+            looped_once = True
+            time.sleep(1)
+            wait_sec = (datetime.now() - started_at).total_seconds()
+
+            logstr = parse_container_logs_to_string(container)
+
+            if contains_any(logstr, strs_to_find):
+                return True
+
+            if contains_any(logstr, strs_to_fail):
+                logging.info("Found failure criteria")
+                found_failure = True
+                break
+
+        if wait_sec >= max_container_readiness_wait_sec:
+            logging.warning("Waited for container readiness for max time of " + str(max_container_readiness_wait_sec) + " seconds before defaulting.")
+        else:
+            logging.info("Exited waiting after " + str(wait_sec) + " seconds.")
+
+        logging.debug("Timed out while waiting for "+container.name+" readiness.")
+
+    except docker.Errors.NotFound:
+        has_exception = not looped_once # This is okay if the container exiting caused a NotFound after being found
+    except Exception:
+        has_exception = True
+        logging.error("Unexpected error in 'wait_for_logs_to_include':", sys.exc_info()[0])
+
+    logging.warning("Container logs:\n"+logstr)
+
+    return not (found_failure or has_exception) # unlike immediate success return True, async returns True if no errors
+
+def contains_any(str_to_search, phrases):
+    for s in phrases:
+        if s.lower() in str_to_search.lower():
+            return True
+    return False
+
+def parse_container_logs_to_string(container):
+    logstr = container.logs()
+    if logstr is None:
+        logstr = ""
+    else:
+        logstr = logstr.decode("utf-8")
+    return logstr
+
+def detach_infra(explicit, all):
+    client = docker.from_env()
+
+    if explicit:
+        upgrade_logging()
+
+    filters = {
+        'label': 'neoload-cli'
+    }
+    if not all:
+        prior = user_data.get_meta(key_meta_prior_docker)
+        if prior is not None and key_docker_run_id in prior:
+            filters = {
+                'label': 'neoload-cli=' + prior[key_docker_run_id]
+            }
+        else:
+            logging.info('No prior Docker attach info, so nothing to do without --all argument')
+            return # nothing to do, so bail
+
+    containers = client.containers.list(
+        all = True,
+        filters = filters,
+    )
+    networks = client.networks.list(
+        filters = filters,
+    )
+    before_count = len(containers) + len(networks)
+    if before_count < 1:
+        logging.info("No containers or networks with 'neoload-cli' label to delete.")
+        return True # nothing to do, so bail
+
+    logging.info("Containers:\n\t" + "\n\t".join(map(lambda x: x.name, containers)))
+    logging.info("Networks:\n\t" + "\n\t".join(map(lambda x: x.name, networks)))
+
+    do_it = 'n'
+    if not explicit:
+        do_it = 'y'
+    elif sys.stdin.isatty():
+        do_it = click.prompt("Are you sure you want to delete all containers and networks with the label '" + filters['label'] + "'? (y/n)", 'n', False)
+
+    if not do_it == 'y':
+        return True # user exited, so bail
+
+    for container in containers:
+        remove_container(client,container.id)
+
+    for network in networks:
+        remove_network(client,network.id)
+
+    logging.info("All containers and networks with label [" + filters['label'] + "] removed.")
+
+
+    containers = client.containers.list(
+        all = True,
+        filters = filters,
+    )
+    networks = client.networks.list(
+        filters = filters,
+    )
+
+    after_count = len(containers) + len(networks)
+
+    logging.info(str(after_count)+" docker artifacts with label=neoload-cli exist.")
+
+    prior = user_data.get_meta(key_meta_prior_docker)
+    if not prior is None:
+        prior.pop(key_docker_run_id, None)
+        user_data.set_meta(key_meta_prior_docker, prior)
+
+    if explicit:
+        downgrade_logging()
+
+    return before_count > 0 and after_count < 1
+
+
+
+def remove_container(client,container_id):
+    try:
+        container = client.containers.get(container_id)
+
+        logging.debug("Container " + container.name + " logs:")
+        #TODO preserve logs? # logging.debug(container.logs().decode("utf-8"))
+
+        logging.info("Stopping container " + container.name)
+        container.stop()
+        if not auto_remove_containers:
+            container.remove()
+
+    except Exception:
+        if "No such container" in str(sys.exc_info()[0]):
+            logging.warning("Tried to remove non-existent container: " + container_id)
+        else:
+            logging.error("Unexpected error in 'remove_container':", sys.exc_info()[0])
+
+
+
+
+def remove_network(client,network_id):
+    logging.info("Removing network " + network_id)
+    try:
+        network = client.networks.get(network_id)
+        network.remove()
+        logging.info("Removed network " + network_id)
+    except Exception:
+        logging.error("Unexpected error in 'remove_network':", sys.exc_info()[0])

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -2,7 +2,7 @@ from urllib.parse import quote
 
 import click
 
-from commands import test_settings, test_results
+from commands import test_settings, test_results, docker
 from neoload_cli_lib import running_tools, tools, rest_crud, user_data
 
 
@@ -34,6 +34,9 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
     if not naming_pattern:
         naming_pattern = "#${runID}"
     naming_pattern = naming_pattern.replace('${runID}', str(test_settings_json['nextRunId']))
+
+    if docker.has_prior_attach():
+        docker.resume_prior_attach()
 
     # Sorry for that, post data are in the query string :'( :'(
     post_result = rest_crud.post(

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -73,6 +73,13 @@ def cli(command, name, rename, description, quality_status, junit_file):
 
     tools.system_exit(system_exit)
 
+def is_current_test_results_set():
+    current_id = user_data.get_meta(meta_key)
+    return (current_id is not None and len(current_id) > 0)
+
+def get_current_test_results_json():
+    return tools.get_named_or_id(user_data.get_meta(meta_key), True, __resolver)
+
 
 def delete(__id):
     rep = tools.delete(__endpoint, __id, "test results")

--- a/neoload/commands/test_settings.py
+++ b/neoload/commands/test_settings.py
@@ -77,6 +77,12 @@ def cli(command, name, rename, description, scenario, controller_zone_id, lg_zon
         delete(__id)
         user_data.set_meta(meta_key, None)
 
+def is_current_test_settings_set():
+    current_id = user_data.get_meta(meta_key)
+    return (current_id is not None and len(current_id) > 0)
+
+def get_current_test_settings_json():
+    return tools.get_named_or_id(user_data.get_meta(meta_key), True, __resolver)
 
 def create(json_data):
     rep = rest_crud.post(__endpoint, fill_default_fields(json_data))

--- a/neoload/neoload_cli_lib/running_tools.py
+++ b/neoload/neoload_cli_lib/running_tools.py
@@ -2,7 +2,7 @@ import datetime
 import time
 from signal import signal, SIGINT
 
-from commands import logs_url, test_results
+from commands import logs_url, test_results, docker
 from neoload_cli_lib import tools, rest_crud
 
 __current_id = None
@@ -30,6 +30,7 @@ def wait(results_id, exit_code_sla):
         time.sleep(20)
 
     __current_id = None
+    docker.cleanup_after_test()
     tools.system_exit(test_results.summary(results_id), exit_code_sla)
 
 
@@ -82,5 +83,6 @@ def stop(results_id, force: bool, quit_option=False):
     policy = 'TERMINATE' if force else 'GRACEFUL'
     if tools.confirm("Do you want stop the test" + results_id + " with " + policy.lower() + " policy ?", quit_option):
         rest_crud.post(__endpoint + results_id + "/stop", {"stopPolicy": policy})
+        docker.cleanup_after_test()
         return True
     return False

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ markers =
     results: marks tests of the "test-results" sub-commands
     validation: marks tests of the validation of project yaml format
     acceptance: marks tests of commands in the readme.md
+    docker: marks tests of the "docker" sub-commands
+    integration: skipped by default; uses $NLW_TOKEN and $NLW_URL to test features that require live system

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'pytest-datafiles',
         'junit_xml',
         'termcolor',
-        'coloredlogs'
+        'coloredlogs',
+        'docker'
     ],
     long_description_content_type='text/markdown',
     long_description=long_description

--- a/tests/commands/docker/docker_test_utils.py
+++ b/tests/commands/docker/docker_test_utils.py
@@ -1,0 +1,151 @@
+
+from commands.docker import cli as docker
+
+from commands.test_settings import cli as settings
+from commands.status import cli as status
+from commands.login import cli as login
+from commands.zones import cli as zones
+
+from helpers.test_utils import *
+import logging
+import traceback
+import sys
+
+import json
+
+# note: there's really no good/fast way to mock responses related to infra attach/detach
+# from the NLW server, at least in this context. the mock_api_post is scoped to requests
+# from python, not system-wide, so the docker containers would need to be proxied to loopback :O=
+
+
+# the reason this is it's own function is that login + test-settings + zone semantics apply to multiple tests
+def setup_lifecycle(runner, before_create=None, after_create=None, between_create_delete=None, before_delete=None, after_delete=None):
+
+    catches = []
+
+    #  list zones, pick first static one, prefer a zone with no existing resources
+    result_zone_ls = runner.invoke(zones,['--static'])
+    listing = json.loads(result_zone_ls.output)
+    fn_prefer = lambda x: (len(x['controllers'])+len(x['loadgenerators']))
+    listing = sorted(listing, key=fn_prefer)
+    found = next(iter(listing), None)
+
+    assert found is not None
+
+    print("Found zone: " + found['name'] + " [" + found['id'] + "]")
+
+    num_of_lgs = 1
+    test_name = generate_test_settings_name()
+    #! create a temp test with unique name
+
+    context = {
+        'runner': runner,
+        'zone': found,
+        'test_name': test_name,
+        'num_of_lgs': num_of_lgs
+    }
+
+    if before_create is not None: before_create(context)
+
+    create_success = False
+
+    try:
+        if before_create is not None: before_create(context)
+
+
+        create_result = runner.invoke(settings, [
+            'create', test_name,
+            '--zone', found['id'],
+            '--lgs', found['id']+':'+str(num_of_lgs),
+            '--scenario', 'sanityScenario'
+        ])
+        assert_success(create_result)
+        create_success = True
+
+        if after_create is not None: after_create(context, create_result)
+
+    except Exception as err:
+        catches.append(err)
+
+    if between_create_delete is not None:
+        try:
+            between_create_delete(context)
+        except Exception as err:
+            catches.append(err)
+
+    if create_success:
+        try: # ensure that errors from top-level code don't impact the imperative to delete temp settings
+            if before_delete is not None: before_delete(context)
+        except Exception as err:
+            catches.append(err)
+
+        try:
+            delete_result = runner.invoke(settings, [
+                'delete', test_name
+            ])
+            assert_success(delete_result)
+
+            if after_delete is not None: after_delete(context, delete_result)
+
+        except Exception as err:
+            catches.append(err)
+
+    if len(catches) > 0:
+        raise catches[0] #Exception("\n".join(map(lambda err: repr(err),catches)))
+
+
+# the reason this is it's own function is because for any attach, there should be a detach; hermetic setup/teardown
+def attach_detach_lifecycle(context, before_attach=None, after_attach=None, between_attach_detach=None, before_detach=None, after_detach=None):
+
+    catches = []
+    runner = context['runner']
+
+    attach_success = False
+    attach_result = None
+    try:
+        if before_attach is not None: before_attach(context)
+
+        args = ['attach']
+
+        if between_attach_detach is None: args.insert(0, "--nowait")
+
+        attach_result = runner.invoke(docker, args)
+        attach_success = True
+
+    except Exception as err:
+        logging.error("Failed in attach_detach_lifecycle::attach[0]" + str(err))
+        catches.append(err)
+
+    try:
+        if after_attach is not None: after_attach(context, attach_result)
+    except Exception as err:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        ex_str = repr(traceback.format_exception(exc_type, exc_value,exc_traceback))
+        logging.error("Failed in attach_detach_lifecycle::attach[1]" + ex_str)
+        catches.append(err)
+
+    if between_attach_detach is not None:
+        try:
+            between_attach_detach(context)
+        except Exception as err:
+            catches.append(err)
+
+    if attach_success:
+        try: # ensure that errors from top-level code don't impact the imperative to detach testing infra
+            if before_detach is not None: before_detach(context)
+        except Exception as err:
+            catches.append(err)
+
+        try:
+            detach_result = runner.invoke(docker, ['--all','detach'])
+            print(detach_result.output)
+            assert_success(detach_result)
+
+            if after_detach is not None: after_detach(context, detach_result)
+
+        except Exception as err:
+            logging.error("Failed in attach_detach_lifecycle::detach")
+            catches.append(err)
+
+    if len(catches) > 0:
+        raise catches[0] #Exception("\n".join(map(lambda err: repr(err),catches)))

--- a/tests/commands/docker/test__docker_system.py
+++ b/tests/commands/docker/test__docker_system.py
@@ -1,0 +1,29 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+from commands.docker import cli as docker
+from commands.docker import try_docker_system
+
+
+import logging
+
+import json
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestDockerSystem:
+
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        result = try_docker_system()
+
+        if not result['success']:
+            if 'connection refused' in result['logs'].lower():
+                logging.error("Docker installed, but connection to dockerd failed.")
+            else:
+                logging.error(result['logs'])
+
+        assert result['success']

--- a/tests/commands/docker/test_attach.py
+++ b/tests/commands/docker/test_attach.py
@@ -1,0 +1,21 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestAttach:
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        def validate(context, result):
+            assert_success(result)
+            assert 'All containers are attached' in result.output
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: attach_detach_lifecycle(context,
+                after_attach=validate
+            )
+        )

--- a/tests/commands/docker/test_detach.py
+++ b/tests/commands/docker/test_detach.py
@@ -1,0 +1,34 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+from commands.docker import cli as docker
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestDetach:
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        def validate(context, result):
+            assert_success(result)
+            print(result.output)
+
+            assert ('No containers or networks' in result.output or
+                    'All containers and networks with' in result.output or
+                    '0 artifacts' in result.output
+            )
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: attach_detach_lifecycle(context,
+                after_detach=validate
+            )
+        )
+
+    def test_all_detach(self, monkeypatch):
+        runner = CliRunner()
+
+        detach_result = runner.invoke(docker, ['--all', 'detach'])
+        assert_success(detach_result)

--- a/tests/commands/docker/test_forget.py
+++ b/tests/commands/docker/test_forget.py
@@ -1,0 +1,47 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+from commands.docker import cli as docker
+from commands.docker import key_meta_prior_docker
+from commands.status import cli as status
+from test_prepare import run_prepare_command
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestForget:
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        def run_prepare_and_forget_commands(runner, context):
+            run_prepare_command(runner, context)
+            run_forget_command(runner, context)
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: run_prepare_and_forget_commands(runner, context)
+        )
+
+    def test_with_prior_attach_and_run_id(self, monkeypatch):
+        runner = CliRunner()
+
+        def run_prepare_attach_forget_commands(runner, context):
+            run_prepare_command(runner, context)
+            attach_result = runner.invoke(docker, ['attach'])
+            assert_success(attach_result)
+            run_forget_command(runner, context)
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: run_prepare_attach_forget_commands(runner, context)
+        )
+
+
+def run_forget_command(runner,context):
+    # forget deletes the meta used by run, docker.key_meta_prior_docker
+    forget_result = runner.invoke(docker, ['forget'])
+    assert_success(forget_result)
+
+    # the sign of a successful prepare is that there is no meta that will be used by 'run'
+    status_result = runner.invoke(status)
+    assert_success(status_result)
+    assert key_meta_prior_docker+': {' not in status_result.output

--- a/tests/commands/docker/test_misc.py
+++ b/tests/commands/docker/test_misc.py
@@ -1,0 +1,71 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+from commands.docker import cli as docker
+from commands.docker import key_meta_prior_docker
+from commands.docker import resume_prior_attach, is_prior_attach_running, cleanup_after_test, detach_infra
+from commands.status import cli as status
+from test_prepare import run_prepare_command
+from test_forget import run_forget_command
+
+import logging
+
+import json
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestMisc:
+
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        def run_prepare_resume_forget(runner, context):
+            run_prepare_command(runner, context)
+            resume_prior_attach()
+            is_prior_attach_running(12345)
+            cleanup_after_test()
+            run_forget_command(runner, context)
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: run_prepare_resume_forget(runner, context)
+        )
+
+
+    # keep in mind, this is a negative test, we are purposely causing and looking for an end-to-end failure
+    def test_when_invalid_zone(self, monkeypatch):
+        runner = CliRunner()
+
+        def mock_test_settings_bork_zone(context, result):
+
+            mock = json.loads(result.output)
+            purposeful_error = "BORK"
+
+            # append purposeful_error to the end of the zone codes, to cause containers to error on attach
+            lgs = mock['lgZoneIds']
+            first_key = list(lgs.keys())[0]
+            first_value = lgs[first_key]
+            lg = lgs.pop(first_key)
+            lgs[first_key+purposeful_error] = first_value
+            mock['lgZoneIds'] = lgs
+            mock['controllerZoneId'] = mock['controllerZoneId'] + purposeful_error
+            context['mock_test_setting'] = mock
+
+            mock_api_get(monkeypatch, 'v2/tests/%s' % mock['id'], json.dumps(mock))
+
+        def validate_borked_attach(context, result):
+
+            assert 'The provided zone identifier is not valid' in result.output
+            assert result.exit_code != 0
+
+            # set up the list of tests to include the same fake test-setting for the next step
+            mock_api_get(monkeypatch, 'v2/tests', json.dumps([context['mock_test_setting']]))
+
+        setup_lifecycle(runner,
+            after_create=mock_test_settings_bork_zone,
+            between_create_delete=lambda context: attach_detach_lifecycle(context,
+                after_attach=validate_borked_attach,
+                between_attach_detach=lambda context: True # cause waiting
+            )
+        )

--- a/tests/commands/docker/test_prepare.py
+++ b/tests/commands/docker/test_prepare.py
@@ -1,0 +1,29 @@
+import pytest
+from click.testing import CliRunner
+from docker_test_utils import *
+
+from commands.docker import cli as docker
+from commands.docker import key_meta_prior_docker
+from commands.status import cli as status
+
+@pytest.mark.docker
+@pytest.mark.integration
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestPrepare:
+    def test_minimal(self, monkeypatch):
+        runner = CliRunner()
+
+        setup_lifecycle(runner,
+            between_create_delete=lambda context: run_prepare_command(runner, context)
+        )
+
+# this is also used by 'forget' tests
+def run_prepare_command(runner, context):
+    # prepare takes from test-settings (created and configured in lifecycle)
+    prepare_result = runner.invoke(docker, ['prepare'])
+    assert_success(prepare_result)
+
+    # the sign of a successful prepare is that there is meta that will be used by 'run'
+    status_result = runner.invoke(status)
+    assert_success(status_result)
+    assert key_meta_prior_docker+': {' in status_result.output

--- a/tests/neoload_projects/yaml_variants/improperly_indented.yaml
+++ b/tests/neoload_projects/yaml_variants/improperly_indented.yaml
@@ -1,0 +1,8 @@
+user_paths:
+- name: path
+  actions:
+    steps:
+    - request:
+          url: /search?format=json&q=${cities.City}
+        server: geolookup_host
+        sla_profile: geo_3rdparty_sla

--- a/tests/neoload_projects/yaml_variants/scenario_invalid_population.yaml
+++ b/tests/neoload_projects/yaml_variants/scenario_invalid_population.yaml
@@ -1,0 +1,10 @@
+scenarios:
+- name: sanityScenario
+  populations:
+  - name: popGets
+    customized_load:
+      min_users: 1
+      max_users: 5
+      increment_users: 1
+      increment_every: 2s
+      durations: 1m

--- a/tests/neoload_projects/yaml_variants/scenario_invalid_values.yaml
+++ b/tests/neoload_projects/yaml_variants/scenario_invalid_values.yaml
@@ -1,0 +1,16 @@
+scenarios:
+- name: sanityScenario
+  populations:
+  - name: popGets
+    peaks_load:
+      minimum:
+        users: 100
+        duration: 5 interations
+      maximum:
+        users: 500a
+        duration: 3 iterations
+      start: minimums
+      duration: 80 iterations
+      start_after: MyPopulation1
+      step_rampup: 15s
+      stop_after: current_iterations

--- a/tests/neoload_projects/yaml_variants/scenario_no_duration.yaml
+++ b/tests/neoload_projects/yaml_variants/scenario_no_duration.yaml
@@ -1,0 +1,10 @@
+scenarios:
+- name: sanityScenario
+  populations:
+  - name: popGets
+    rampup_load:
+      min_users: 1
+      max_users: 5
+      increment_users: 1
+      increment_every: 2s
+      durations: 1m

--- a/tests/neoload_projects/yaml_variants/scenario_no_populations.yaml
+++ b/tests/neoload_projects/yaml_variants/scenario_no_populations.yaml
@@ -1,0 +1,12 @@
+scenarios:
+- name: anotherScenario
+  populations:
+- name: sanityScenario
+  populations:
+  - name: popGets
+    customized_load:
+      min_users: 1
+      max_users: 5
+      increment_users: 1
+      increment_every: 2s
+      durations: 1m

--- a/tests/neoload_projects/yaml_variants/user_path_invalid_elements.yaml
+++ b/tests/neoload_projects/yaml_variants/user_path_invalid_elements.yaml
@@ -1,0 +1,18 @@
+user_paths:
+- name: ex_2_0_geosearch_get
+  actions:
+    steps:
+    - invalid_step:
+        something: is wrong
+    - transaction:
+        name: External Geo-lookup
+        description: Call Open Street Maps to translate city names to lat/lon
+        steps:
+        - request:
+            url: /search?format=json&q=${cities.City}
+            server: geolookup_host
+            sla_profile: geo_3rdparty_sla
+    - request:
+        url: /search?format=json&q=${cities.City}
+        server: geolookup_host
+        sla_profile: geo_3rdparty_sla

--- a/tests/neoload_projects/yaml_variants/user_path_no_actions_container.yaml
+++ b/tests/neoload_projects/yaml_variants/user_path_no_actions_container.yaml
@@ -1,0 +1,8 @@
+user_paths:
+- name: ex_2_0_geosearch_get
+  init:
+    steps:
+    - request:
+        url: /search?format=json&q=${cities.City}
+        server: geolookup_host
+        sla_profile: geo_3rdparty_sla

--- a/tests/neoload_projects/yaml_variants/user_path_no_request_url.yaml
+++ b/tests/neoload_projects/yaml_variants/user_path_no_request_url.yaml
@@ -1,0 +1,7 @@
+user_paths:
+- name: path
+  actions:
+    steps:
+    - request:
+        server: geolookup_host
+        sla_profile: geo_3rdparty_sla

--- a/tests/neoload_projects/yaml_variants/valid_user_path.yaml
+++ b/tests/neoload_projects/yaml_variants/valid_user_path.yaml
@@ -1,0 +1,15 @@
+user_paths:
+- name: ex_2_0_geosearch_get
+  actions:
+    steps:
+
+    - transaction:
+        name: External Geo-lookup
+        description: Call Open Street Maps to translate city names to lat/lon
+        steps:
+        - request:
+            url: /search?format=json&q=${cities.City}
+            server: geolookup_host
+            sla_profile: geo_3rdparty_sla
+
+    - delay: 1s

--- a/tests/neoload_projects/yaml_variants/validate_all.sh
+++ b/tests/neoload_projects/yaml_variants/validate_all.sh
@@ -1,0 +1,61 @@
+set +e
+
+output=""
+lastrun=""
+function runthis(){
+  lastrun=$1
+  output=`$1  &> /dev/null`
+}
+error_if_errored(){
+  if [ "$?" -ne "0" ]; then
+    echo "POSITIVE TEST: shouldn't have failed, but did"
+    echo $lastrun
+    output=`$lastrun`
+    echo $output
+    return
+  else
+    return 1
+  fi
+}
+error_if_should_have_errored_but_didnt(){
+  if [ "$?" -eq "0" ]; then
+    echo "NEGATIVE TEST: should have failed, but didn't"
+    echo $lastrun
+    output=`$lastrun`
+    echo $output
+    return
+  else
+    return 1
+  fi
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+for i in $(ls -1 -d "$DIR/"*.yaml); do
+  echo "Running $i"
+  runthis "neoload validate $i"
+  if [[ "$i" =~ .*/valid_.* ]]; then
+    if error_if_errored; then exit 5500; fi
+  else
+    if error_if_should_have_errored_but_didnt; then exit 5500; fi
+  fi
+done
+
+
+runthis "neoload validate $DIR/improperly_indented.yaml"
+if error_if_should_have_errored_but_didnt; then exit 5500; fi
+
+runthis "neoload validate $DIR/missing_request_url.yaml"
+if error_if_should_have_errored_but_didnt; then exit 5500; fi
+
+runthis "neoload validate $DIR/no_scenario_duration.yaml"
+if error_if_should_have_errored_but_didnt; then exit 5500; fi
+
+runthis "neoload validate $DIR/user_path_invalid_elements.yaml"
+if error_if_should_have_errored_but_didnt; then exit 5500; fi
+
+runthis "neoload validate $DIR/user_path_no_actions_container.yaml"
+if error_if_should_have_errored_but_didnt; then exit 5500; fi
+
+echo "All POSITIVE and NEGATIVE validations passed."
+set -e


### PR DESCRIPTION
## What?
Support for automating the launch and attachment of local NeoLoad controller and load generator containers adequate to run the current test-settings.

## Why?
Tests need infrastructure to run, plain and simple. It is not always the case that these resources are already available when someone wants to simply run a quick test of their neoload project via NCLI. It should be quick and easy in a PoC as well as on a day-to-day basis to spin up infrastructure, run the test, and spin it down in an ad-hoc manner. 

With the NCLI, the classic NLG is not assumed to be installed, even still that manual configuration of agents and attachment is a desirable part of the workflow described above. Why not do this for them by using Docker (if available)? Both on the desktop and in CI environments where Docker (socket) is available, this dramatically simplifies the process of "bringing your own infra to the table".

## How?
Using the Docker API for Python, add a command "neoload docker" with lifecycle subcommands to handle attachment, detachment, preparation (settings only for chain command with "run" to auto setup/teardown), and forget docker settings activities. If docker isn't installed or working properly (ps command doesn't work), that's not our fault and fail any docker-related commands using this quick check.

'prepare' --> Simply translates the # of LGs, zone, and profile connection info into a spec remembered as metadata in the user profile. This comes in handy when wanting a "run" call to pre-run the docker attachment process and then the docker detachment process after the test is done.

'attach' --> Takes test-settings and options, remembers them in profile metadata, and actually automates Docker (whatever socket is attached, local or remote) to spin up one controller and X# of load generators (from test-settings) containers, providing them the proper NLW url, token, zone, and local mapping to each other. These containers will always be able to talk to each other directly.

'detach' --> stops any containers associated with the prior command 'attach'; the --all option also includes any containers (possibly from duplicate calls) to be decommissioned as well...a sort of "clean up everything" command, regardless of which came from the most recent attachment.

'forget' --> stops current containers (if running) and removes profile metadata so that subsequent calls to 'run' do not try to auto-start old docker infra specs.

## Testing
Originally, I had integration-style tests in the tests folder, however we need a live system to test these. It cannot all be done with simple monkeypatch mocks. Though this works in Travis because the build node has a docker socket attached, I don't know if there's a better way. Currently we can keep these tests to requiring a live environment and not to be executed with the default [unit] test suite. If we make changes to this functionality, we should run the integration tests manually/locally, and maybe compensate later on with a nightly/weekly integration suite run somewhere else. Integration tests ARE required though for this functionality.

## Supportability
We can explicitly call out that this is not the preferred production way to handle infra at large scale, but rather use dynamic infra or existing static zones. Since we do not support the customers local docker deployment or the Docker API libraries, it should be considered as "use for local development and at-your-own-risk". Support should not be troubleshooting the world of Docker on Windows and all it's faults. If the user can run a command line such as "docker ps" and get back non-error results, our docker command should work for experimental activities (such as sanity checks and CI when no infra is available).

## Additional Notes
With docker and the neoload-cli installed, usage should be as simple as adding this to the TL;DR usage example:

neoload login $NLW_TOKEN \
        test-settings --zone $NLW_ZONE_DYNAMIC --lgs 5 --scenario sanityScenario createorpatch NewTest1 \
        project --path tests/neoload_projects/example_1 upload NewTest1 \
        docker prepare
        run

Before executing the normal 'run' logistics, the run.py should see the prepared metadata, spin up the resources, then run the test, then finally spin them down. If the docker resources are already running (such as in an explicit call to 'attach'), the run command does nothing extra, neither spin up nor spin down. If prepared and the containers can't spin up, the CLI should fail there and not try to launch the test.

Each call to commands that might invalidate the current zone, such as login/logout/test-settings, should re-run the prepare and/or attach commands after switching test-settings. If attachment fails in this context, it should be a warning, not a hard error, requiring the user to re-run the appropriate command explicitly.

If long-running docker containers are preferred, these should be separate commands:

neoload login $NLW_TOKEN \
        test-settings --zone $NLW_ZONE_DYNAMIC --lgs 5 --scenario sanityScenario createorpatch NewTest1 \
        docker attach

neoload project --path tests/neoload_projects/example_1 upload NewTest1 \
        run

neoload docker detach

Both models are useful from the desktop when test suites are being written/tested/sanity-checked.

The attach/detach provides CI systems such as Jenkins explicit control over provably disposing of containers (in a finally or always block) if parts of the test fail but containers are still running.
