### PR TITLE
Topic workspace compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,27 @@ pip3 install certifi
 NeoLoad CLI defaults to using the NeoLoad Web APIs for most operations. That's why you need to login.
 ```
 neoload login [TOKEN]
-neoload login --url http://your-onpremise-neoload-api.com/ your-token
+neoload login --url http://your-onpremise-neoload-api.com/ --workspace "Default Workspace" your-token
 ```
 The CLI will connect by default to Neoload Web SaaS to lease license. \
-For self-hosted enterprise license, you must specify the Neoload Web Api url with --url. \
+For self-hosted enterprise license, you must specify the Neoload Web **Api url** with --url. \
 \
-The CLI stores data locally like api url, token, and the test ID you are working on. **The commands can be chained !**
+The CLI stores data locally like api url, token, the workspace ID and the test ID you are working on. **The commands can be chained !**
 ```
 neoload status          # Displays stored data
 ```
 
 ## Setup a test
+### Choose a workspace to work with
+```
+Usage: neoload workspaces [OPTIONS] [[ls|use]] [NAME_OR_ID]
+neoload workspaces use "Default Workspace"
+```
+Since Neoload Web 2.5 (August 2020), assets are scoped to workspaces.
+The CLI allows you to choose your workspace at login or with the "use" sub-command, otherwise the "Default Workspace" is used.\
+**/!\\** The zones are shared between workspaces.
+
+
 ### Setup resources in Neoload Web
 Run a test requires an infrastructure that is defined in Neoload Web Zones section [(see documentation how to manage zones)](https://www.neotys.com/documents/doc/nlweb/latest/en/html/#27521.htm#o39458)
 You must at least have either a dynamic or a static zone with one controller and one load generator. At First, you could add resources to the "Default zone" since the CLI use it by default.

--- a/neoload/commands/login.py
+++ b/neoload/commands/login.py
@@ -1,16 +1,18 @@
 import sys
 import click
 
-from neoload_cli_lib import user_data
+from commands import workspaces
+from neoload_cli_lib import user_data, tools
 
 
 @click.command()
 @click.option('--url', default="https://neoload-api.saas.neotys.com/", help="The URL of api ", metavar='URL')
 @click.option('--no-write', is_flag=True, help="don't save login on application data")
+@click.option('--workspace', help="The Neoload Web workspace name or id. Optional. If not set, use the API v2 bound to the default workspace.")
 @click.argument('token', required=False)
-def cli(token, url, no_write):
-    """Store your token and uri of NeoLoad Web. The token is read from stdin if none is set.
-    The default url is "https://neoload-api.saas.neotys.com/" """
+def cli(token, url, no_write, workspace):
+    """Store your token and API url of NeoLoad Web. The token is read from stdin if none is set.
+    The default API url is "https://neoload-api.saas.neotys.com/" """
     if not token:
         if sys.stdin.isatty():
             token = click.prompt("Enter your token", None, True)
@@ -18,5 +20,14 @@ def cli(token, url, no_write):
             token = input()
 
     __user_data = user_data.do_login(token, url, no_write)
+
+    if workspace is not None:
+        if user_data.is_version_lower_than('2.5.0'):
+            print("WARNING: The workspace option works only since Neoload Web 2.5.0. The specified workspace is ignored.")
+        else:
+            is_workspace_id = tools.is_mongodb_id(workspace)
+            __id = tools.get_id(workspace, workspaces.__resolver, is_workspace_id)
+            tools.use(__id, workspaces.meta_key, workspaces.__resolver)
+
     if sys.stdin.isatty():
         print(__user_data)

--- a/neoload/commands/logs_url.py
+++ b/neoload/commands/logs_url.py
@@ -20,4 +20,4 @@ def get_url(name: str):
 
 def get_endpoint(name: str):
     __id = tools.get_id(name, test_results.__resolver)
-    return '/#!result/%s/overview' % __id
+    return '#!result/%s/overview' % __id

--- a/neoload/commands/project.py
+++ b/neoload/commands/project.py
@@ -25,8 +25,12 @@ def cli(command, name_or_id, path):
 
 
 def upload(path, settings_id):
-    neoLoad_project.upload_project(path, "v2/tests/" + settings_id + "/project")
+    neoLoad_project.upload_project(path, get_endpoint(settings_id))
 
 
 def meta_data(setting_id):
-    neoLoad_project.display_project(rest_crud.get_from_file_storage('v2/tests/' + setting_id + "/project"))
+    neoLoad_project.display_project(rest_crud.get_from_file_storage(get_endpoint(setting_id)))
+
+
+def get_endpoint(settings_id: str):
+    return rest_crud.base_endpoint_with_workspace() + '/tests/' + settings_id + "/project"

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -37,7 +37,7 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
 
     # Sorry for that, post data are in the query string :'( :'(
     post_result = rest_crud.post(
-        'v2/tests/%s/start?%s' % (_id, create_data(naming_pattern, description, as_code, web_vu, sap_vu, citrix_vu)),
+        test_settings.get_end_point(_id) + '/start?' + create_data(naming_pattern, description, as_code, web_vu, sap_vu, citrix_vu),
         {})
     user_data.set_meta(test_settings.meta_key, _id)
     user_data.set_meta(test_results.meta_key, post_result['resultId'])

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -6,7 +6,7 @@ import click
 from neoload_cli_lib import tools, rest_crud, user_data, displayer, cli_exception
 from neoload_cli_lib.name_resolver import Resolver
 
-__endpoint = "v2/test-results"
+__endpoint = rest_crud.base_endpoint_with_workspace() + "/test-results"
 __operation_statistics = "/statistics"
 __operation_sla_global = "/slas/statistics"
 __operation_sla_test = "/slas/per-test"

--- a/neoload/commands/test_settings.py
+++ b/neoload/commands/test_settings.py
@@ -11,7 +11,7 @@ from neoload_cli_lib.name_resolver import Resolver
 
 import logging
 
-__endpoint = "v2/tests"
+__endpoint = rest_crud.base_endpoint_with_workspace() + "/tests"
 __resolver = Resolver(__endpoint)
 
 meta_key = 'settings id'

--- a/neoload/commands/workspaces.py
+++ b/neoload/commands/workspaces.py
@@ -1,0 +1,39 @@
+import click
+from neoload_cli_lib import rest_crud, tools, user_data, cli_exception
+from neoload_cli_lib.name_resolver import Resolver
+
+__endpoint = "v3/workspaces"
+__resolver = Resolver(__endpoint)
+meta_key = 'workspace id'
+
+
+@click.command()
+@click.argument('command', type=click.Choice(['ls', 'use'], case_sensitive=False), required=False)
+@click.argument("name_or_id", type=str, required=False)
+def cli(command, name_or_id):
+    """
+    ls     # Lists workspaces                                                .
+    use    # Remember the workspace you want to work on                      .
+    """
+    if not command:
+        print("command is mandatory. Please see neoload workspaces --help")
+        return
+    if user_data.is_version_lower_than('2.5.0'):
+        print("ERROR: This commands works only since Neoload Web 2.5.0")
+        return
+    rest_crud.set_current_sub_command(command)
+    if name_or_id == "cur":
+        name_or_id = user_data.get_meta(meta_key)
+    is_id = tools.is_mongodb_id(name_or_id)
+    # avoid to make two requests if we have not id.
+    if command == "ls":
+        # The endpoint GET /workspaces/{workspaceId} is not yet implemented
+        if name_or_id is not None:
+            print("ERROR: Unable to display only one workspace. API endoint not yet implemented. Please use command neoload workspaces ls without name or ID")
+        tools.ls(name_or_id, is_id, __resolver)
+        return
+
+    __id = tools.get_id(name_or_id, __resolver, is_id)
+
+    if command == "use":
+        tools.use(__id, meta_key, __resolver)

--- a/neoload/commands/zones.py
+++ b/neoload/commands/zones.py
@@ -1,6 +1,8 @@
 import click
 from neoload_cli_lib import rest_crud, tools
 
+__endpoint = rest_crud.base_endpoint() + "/resources/zones"
+
 
 @click.command()
 @click.argument("name_or_id", type=str, required=False)
@@ -8,7 +10,7 @@ from neoload_cli_lib import rest_crud, tools
 @click.option("--static/--dynamic", "static_dynamic", default=None, help="filter for dynamic or static zones")
 def cli(name_or_id, static_dynamic, human):
     """read of NeoLoad Web zones"""
-    resp = rest_crud.get("/v2/resources/zones")
+    resp = rest_crud.get(__endpoint)
     resp = [elem for elem in resp if filter_result(elem, name_or_id, static_dynamic)]
     if human:
         print_human(resp)

--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -3,6 +3,7 @@ import urllib.parse as urlparse
 
 import requests
 
+from commands import workspaces
 from version import __version__
 from neoload_cli_lib import user_data, cli_exception
 
@@ -20,6 +21,15 @@ def set_current_command(command: str):
 def set_current_sub_command(command: str):
     global __current_sub_command
     __current_sub_command = command
+
+
+def base_endpoint_with_workspace():
+    workspace_id = user_data.get_meta(workspaces.meta_key)
+    return "v2" if workspace_id is None else "v3/workspaces/" + workspace_id
+
+
+def base_endpoint():
+    return "v2" if user_data.is_version_lower_than('2.5.0') else "v3"
 
 
 def get(endpoint: str):

--- a/neoload/neoload_cli_lib/running_tools.py
+++ b/neoload/neoload_cli_lib/running_tools.py
@@ -6,7 +6,6 @@ from commands import logs_url, test_results
 from neoload_cli_lib import tools, rest_crud
 
 __current_id = None
-__endpoint = "v2/test-results/"
 __count = 0
 
 __last_status = ""
@@ -41,7 +40,7 @@ def header_status(results_id):
 # INIT, STARTING, RUNNING, TERMINATED
 def display_status(results_id):
     global __last_status
-    res = rest_crud.get('v2/test-results/' + results_id)
+    res = rest_crud.get(test_results.get_end_point(results_id))
     status = res.get('status')
 
     if __last_status != status:
@@ -56,7 +55,7 @@ def display_status(results_id):
 
 
 def display_statistics(results_id, json_summary):
-    res = rest_crud.get(__endpoint + results_id + '/statistics')
+    res = rest_crud.get(test_results.get_end_point(results_id, '/statistics'))
     time_cur = datetime.datetime.now() - datetime.datetime.fromtimestamp((json_summary['startDate'] + 1) / 1000)
     time_cur_format = format_delta(time_cur)
     lg_count = json_summary.get('lgCount') or '--'
@@ -81,6 +80,6 @@ def format_delta(delta):
 def stop(results_id, force: bool, quit_option=False):
     policy = 'TERMINATE' if force else 'GRACEFUL'
     if tools.confirm("Do you want stop the test" + results_id + " with " + policy.lower() + " policy ?", quit_option):
-        rest_crud.post(__endpoint + results_id + "/stop", {"stopPolicy": policy})
+        rest_crud.post(test_results.get_end_point(results_id, "/stop"), {"stopPolicy": policy})
         return True
     return False

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -9,6 +9,7 @@ from termcolor import cprint
 from neoload_cli_lib import rest_crud, user_data
 
 __regex_id = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
+__regex_mongodb_id = re.compile('[a-f\\d]{24}', re.IGNORECASE)
 
 __batch = False
 
@@ -16,6 +17,12 @@ __batch = False
 def set_batch(batch: bool):
     global __batch
     __batch = batch
+
+
+def is_mongodb_id(chain: str):
+    if chain:
+        return __regex_mongodb_id.match(chain)
+    return False
 
 
 def is_id(chain: str):

--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import appdirs
 import yaml
@@ -145,6 +146,24 @@ def set_meta(key, value):
 
 def get_meta(key):
     return get_user_data().metadata.get(key, None)
+
+
+def is_version_lower_than(version: str):
+    return __version_to_int(get_user_data().get_version()) < __version_to_int(version)
+
+
+def __version_to_int(version: str):
+    if version.lower() == 'saas':
+        return sys.maxsize
+    elif version.lower() == 'legacy':
+        return -1
+
+    version_as_int = 0
+    offset = 1
+    for digit in reversed(version.split('.')):
+        version_as_int += int(digit) * offset
+        offset *= 1000
+    return version_as_int
 
 
 def get_meta_required(key):

--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -46,9 +46,10 @@ def get_front_url_by_private_entrypoint():
 
 
 def __compute_version_and_path():
-    file_storage = get_file_storage_from_swagger()
-    front = get_front_url_by_private_entrypoint()
-    __user_data_singleton.set_url(front, file_storage, None)
+    if get_nlweb_information() is False:
+        file_storage = get_file_storage_from_swagger()
+        front = get_front_url_by_private_entrypoint()
+        __user_data_singleton.set_url(front, file_storage, None)
 
 
 def get_file_storage_from_swagger():
@@ -58,10 +59,10 @@ def get_file_storage_from_swagger():
 
 
 def get_nlweb_information():
-    response = rest_crud.get_raw('v2/informations')
+    response = rest_crud.get_raw('v3/information')
     if response.status_code == 200:
         json = response.json()
-        __user_data_singleton.url(json['front_url'], json['filestorage_url'], json['version'])
+        __user_data_singleton.set_url(json['front_url'], json['filestorage_url'], json['version'])
         return True
     else:
         return False

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ markers =
     results: marks tests of the "test-results" sub-commands
     validation: marks tests of the validation of project yaml format
     acceptance: marks tests of commands in the readme.md
+    workspaces: marks tests of the "workspaces" sub-commands

--- a/tests/commands/test_login.py
+++ b/tests/commands/test_login.py
@@ -9,25 +9,112 @@ from neoload_cli_lib.user_data import get_user_data
 
 @pytest.mark.authentication
 class TestLogin:
-    def test_login_basic(self, monkeypatch):
+    def test_login_basic(self, monkeypatch, request):
+        mock_api_get_raw(monkeypatch, 'v3/information', 200,
+                         '{"front_url":"https://neoload.saas.neotys.com/", "filestorage_url":"https://neoload-files.saas.neotys.com", "version":"SaaS"}')
+        token = request.config.getoption('--token')
+        runner = CliRunner()
+        result = runner.invoke(login, ['123456789fe70bf4a991ae6d8af62e21c4a00203abcdef' if token is None else token])
+        assert_success(result)
+        result = runner.invoke(status)
+        assert_success(result)
+        assert 'You are logged on https://neoload-api.saas.neotys.com/ with token **' in result.output
+        assert 'frontend url: https://neoload.saas.neotys.com' in result.output
+        assert 'file storage url: https://neoload-files.saas.neotys.com' in result.output
+        assert 'version: SaaS' in result.output
+
+    def test_login_prompt(self, monkeypatch, request):
+        mock_api_get_raw(monkeypatch, 'v3/information', 200,
+                         '{"front_url":"https://neoload.saas.neotys.com/", "filestorage_url":"https://neoload-files.saas.neotys.com", "version":"SaaS"}')
+        token = request.config.getoption('--token')
+        runner = CliRunner()
+        result = runner.invoke(login, [], input='totoken' if token is None else token)
+        assert_success(result)
+        result = runner.invoke(status)
+        assert_success(result)
+        assert 'You are logged on https://neoload-api.saas.neotys.com/ with token **' in result.output
+        assert 'frontend url: https://neoload.saas.neotys.com' in result.output
+        assert 'file storage url: https://neoload-files.saas.neotys.com' in result.output
+        assert 'version: SaaS' in result.output
+
+    def test_login_unauthorized(self, monkeypatch, request):
+        mock_api_get_raw(monkeypatch, 'v3/information', 401, '{"message" : "Unauthorized, "}')
+        runner = CliRunner()
+        result = runner.invoke(login, ['bad_token'])
+        assert result.exit_code == 1
+        assert '"message" : "Unauthorized' in str(result.output)
+
+    def test_login_nlw_before_2_5_0(self, monkeypatch):
+        if monkeypatch is None:
+            # Skip this test when using the production environment (the version is always SaaS)
+            return
+
+        mock_api_get_raw(monkeypatch, 'v3/information', 404, '')
         if monkeypatch is not None:
-            monkeypatch.setattr(user_data, '__compute_version_and_path',
-                                lambda: get_user_data().set_url('http://front', 'http://files', '1.2.3'))
+            monkeypatch.setattr(user_data, 'get_front_url_by_private_entrypoint',
+                                lambda: 'http://old-front')
+            monkeypatch.setattr(user_data, 'get_file_storage_from_swagger',
+                                lambda: 'http://old-files')
         runner = CliRunner()
         result = runner.invoke(login, ['123456789fe70bf4a991ae6d8af62e21c4a00203abcdef'])
         assert_success(result)
         result = runner.invoke(status)
         assert_success(result)
         assert 'You are logged on https://neoload-api.saas.neotys.com/ with token **' in result.output
-        assert 'frontend url: http' in result.output
-        assert 'file storage url: http' in result.output
-        assert 'version: ' in result.output
+        assert 'frontend url: http://old-front' in result.output
+        assert 'file storage url: http://old-files' in result.output
+        assert 'version: legacy' in result.output
 
-    def test_login_prompt(self):
+    def test_login_workspace_before_2_5_0(self, monkeypatch):
+        if monkeypatch is None:
+            # Skip this test when using the production environment (the version is always SaaS)
+            return
+
+        mock_api_get_raw(monkeypatch, 'v3/information', 200,
+                         '{"front_url":"https://neoload.saas.neotys.com/", "filestorage_url":"https://neoload-files.saas.neotys.com", "version":"2.4.0"}')
+        runner = CliRunner()
+        result = runner.invoke(login, ['--workspace', '5e3acde2e860a132744ca916',
+                                       '123456789fe70bf4a991ae6d8af62e21c4a00203abcdef'])
+        assert 'WARNING: The workspace option works only since Neoload Web 2.5.0. The specified workspace is ignored' in result.output
+        assert_success(result)
+        result = runner.invoke(status)
+        assert_success(result)
+        assert 'You are logged on https://neoload-api.saas.neotys.com/ with token **' in result.output
+        assert 'frontend url: https://neoload.saas.neotys.com/' in result.output
+        assert 'file storage url: https://neoload-files.saas.neotys.com' in result.output
+        assert 'version: 2.4.0' in result.output
+
+    def test_login_workspace(self, monkeypatch, request):
+        mock_api_get_raw(monkeypatch, 'v3/information', 200,
+                         '{"front_url":"https://neoload.saas.neotys.com/", "filestorage_url":"https://neoload-files.saas.neotys.com", "version":"SaaS"}')
+        token = request.config.getoption('--token')
+        runner = CliRunner()
+        result = runner.invoke(login, ['--workspace', '5e3acde2e860a132744ca916',
+                                       '123456789fe70bf4a991ae6d8af62e21c4a00203abcdef' if token is None else token])
+        assert_success(result)
+        result = runner.invoke(status)
+        assert_success(result)
+        assert 'You are logged on https://neoload-api.saas.neotys.com/ with token **' in result.output
+        assert 'frontend url: https://neoload.saas.neotys.com' in result.output
+        assert 'file storage url: https://neoload-files.saas.neotys.com' in result.output
+        assert 'workspace id: 5e3acde2e860a132744ca916' in result.output
+        assert 'version: SaaS' in result.output
+
+    def test_login_frontend_url(self, monkeypatch, request):
+        mock_api_get_raw(monkeypatch, 'v3/information', 200, '<html>the frontend page</html>')
+        token = request.config.getoption('--token')
+        runner = CliRunner()
+        result = runner.invoke(login, ['--url', 'https://neoload.saas.neotys.com', '123456789fe70bf4a991ae6d8af62e21c4a00203abcdef' if token is None else token])
+        assert result.exit_code == 1
+        assert 'Error: Unable to parse the response of the server. Did you set the frontend URL instead of the API url ? Details: Expecting value: line 1 column 1' in str(
+            result.output)
+
+    def test_login_bad_url(self, monkeypatch):
         runner = CliRunner()
         result = runner.invoke(login, ['--url', 'someURL'], input='token')
         assert result.exit_code == 1
-        assert "Invalid URL 'explore/v2/swagger.yaml': No schema supplied" in str(result)
+        assert "Unable to reach Neoload Web API. The URL must start with https:// or http://. Details: Invalid URL" in str(
+            result.output)
 
     def test_login_token_required(self):
         runner = CliRunner()

--- a/tests/commands/test_logs_url.py
+++ b/tests/commands/test_logs_url.py
@@ -2,29 +2,23 @@ import json
 import re
 import pytest
 from click.testing import CliRunner
-from commands.login import cli as login
 from commands.test_results import cli as results
 from commands.logs_url import cli as logs_url
 from helpers.test_utils import assert_success, mock_api_get
 from neoload_cli_lib import user_data
-from neoload_cli_lib.user_data import get_user_data
+from neoload_cli_lib.user_data import UserData
 
 
 @pytest.mark.authentication
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
 class TestLogsUrl:
     def test_logs(self, monkeypatch):
         runner = CliRunner()
-        if monkeypatch is not None:
-            monkeypatch.setattr(user_data, '__compute_version_and_path',
-                                lambda: get_user_data().set_url('http://front', 'http://files', '1.2.3'))
-        login_result = runner.invoke(login, ['123456789fe70bf4a991ae6d8af62e21c4a00203abcdef'])
-        assert_success(login_result)
-
+        frontend_url = user_data.get_user_data().get_frontend_url()
         result = runner.invoke(logs_url, ['70ed01da-f291-4e29-b75c-1f7977edf252'])
         assert_success(result)
-        assert re.compile('http[s]?://.*/#!result/.*/overview', re.DOTALL).match(result.output) is not None
+        assert frontend_url + '#!result/70ed01da-f291-4e29-b75c-1f7977edf252/overview\n' == result.output
 
-    @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
     def test_logs_with_name(self, monkeypatch):
         runner = CliRunner()
         mock_api_get(monkeypatch, 'v2/test-results',
@@ -39,14 +33,11 @@ class TestLogsUrl:
         result_use = runner.invoke(results, ['use', json_first_test_result_name])
         assert_success(result_use)
 
-        mock_api_get(monkeypatch, 'nlweb/rest/rest-api/url-api/v1/action/get-front-end-url',
-                     '{"frontEndUrl":{"pathFormatMap":{"HOME":"https://neoload.saas.neotys.com/#!",'
-                     '"RESULT_OVERVIEW":"https://neoload.saas.neotys.com/#!result/:benchId/overview"}}}')
+        frontend_url = user_data.get_user_data().get_frontend_url()
         result = runner.invoke(logs_url, [json_first_test_result_name])
-        assert '#!result/%s/overview' % json_first_test_result_id in result.output
         assert_success(result)
+        assert frontend_url + '#!result/%s/overview\n' % json_first_test_result_id == result.output
 
-    @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
     def test_logs_required(self):
         runner = CliRunner()
         result = runner.invoke(logs_url)

--- a/tests/commands/workspaces/test_workspace_ls.py
+++ b/tests/commands/workspaces/test_workspace_ls.py
@@ -1,0 +1,36 @@
+import pytest
+from click.testing import CliRunner
+from commands.workspaces import cli as workspaces
+from commands.logout import cli as logout
+from helpers.test_utils import *
+
+
+@pytest.mark.workspaces
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestWorkspaceLs:
+    def test_list_all(self, monkeypatch):
+        runner = CliRunner()
+        mock_api_get(monkeypatch, 'v3/workspaces',
+                     '[{"id":"someId", "name":"Default workspace", "description":".... "},'
+                     '{"id":"someId", "name":"19377", "description":".... "}]')
+        result_ls = runner.invoke(workspaces, ['ls'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert json_result[0]['id'] == 'someId'
+        assert json_result[0]['name'] == 'Default workspace'
+        assert json_result[0]['description'] == '.... '
+
+    def test_list_one(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        result = runner.invoke(workspaces, ['ls', valid_data.default_workspace_id])
+        assert result.exit_code == 1
+        assert 'ERROR: Unable to display only one workspace. API endoint not yet implemented' in result.output
+
+    def test_error_not_logged_in(self):
+        runner = CliRunner()
+        result_logout = runner.invoke(logout)
+        assert_success(result_logout)
+
+        result = runner.invoke(workspaces, ['ls'])
+        assert result.exit_code == 1
+        assert 'You are\'nt logged' in str(result.output)

--- a/tests/commands/workspaces/test_workspace_use.py
+++ b/tests/commands/workspaces/test_workspace_use.py
@@ -1,0 +1,42 @@
+import pytest
+from click.testing import CliRunner
+
+from commands.status import cli as status
+from commands.workspaces import cli as workspaces
+from commands.logout import cli as logout
+from helpers.test_utils import *
+
+
+@pytest.mark.workspaces
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestWorkspaceUse:
+    def test_use_id(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        result_use = runner.invoke(workspaces, ['use', valid_data.default_workspace_id])
+        assert_success(result_use)
+        assert '' == result_use.output
+        result_status = runner.invoke(status)
+        assert_success(result_status)
+        assert 'workspace id: %s' % valid_data.default_workspace_id in result_status.output
+        runner.invoke(logout)
+
+    def test_use_name(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get(monkeypatch, 'v3/workspaces',
+                     '[{"id":"%s", "name":"Default workspace", "description":".... "},'
+                     '{"id":"someId", "name":"19377", "description":".... "}]' % valid_data.default_workspace_id)
+        result_use = runner.invoke(workspaces, ['use', 'Default workspace'])
+        assert_success(result_use)
+        assert '' == result_use.output
+        result_status = runner.invoke(status)
+        assert_success(result_status)
+        assert 'workspace id: %s' % valid_data.default_workspace_id in result_status.output
+
+    def test_use_bad_name(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get(monkeypatch, 'v3/workspaces',
+                     '[{"id":"%s", "name":"Default workspace", "description":".... "},'
+                     '{"id":"someId", "name":"19377", "description":".... "}]' % valid_data.default_workspace_id)
+        result_use = runner.invoke(workspaces, ['use', 'Default workspac_WITH_TYPO'])
+        assert result_use.exit_code == 1
+        assert "Error: No id associated to the name 'Default workspac_WITH_TYPO'" in result_use.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,31 @@
 import pytest
 from types import SimpleNamespace
+from _pytest.main import Session
 from click.testing import CliRunner
 from commands.login import cli as login
 from commands.status import cli as status
+from helpers.test_utils import mock_login_get_urls
 
 import sys
 
 sys.path.append('neoload')
 __default_random_token = '12345678912345678901ae6d8af6abcdefabcdefabcdef'
-__default_api_url = 'https://neoload-api.saas.neotys.com/'
+__default_api_url = 'https://preprod-neoload-api.saas.neotys.com/'
 
 
 def pytest_addoption(parser):
     parser.addoption('--token', action='store', default=__default_random_token)
     parser.addoption('--url', action='store', default=__default_api_url)
+
+
+def pytest_sessionstart(session: Session):
+    """
+    Called after the Session object has been created
+    and before performing collection and entering the run test loop.
+    The test suite needs to start already logged in, because during the class initialization
+    of the commands, the function base_endpoint_with_workspace() throw an exception if not logged in.
+    """
+    CliRunner().invoke(login, ["xxxxx", '--url', "bad_url"])
 
 
 @pytest.fixture
@@ -26,6 +38,7 @@ def neoload_login(request, monkeypatch):
     if "aren't logged in" in result_status.output \
             or api_url not in result_status.output \
             or '*' * (len(token) - 3) + token[-3:] not in result_status.output:
+        mock_login_get_urls(monkeypatch)
         runner.invoke(login, [token, '--url', api_url])
         print('\n@Before : %s' % str(runner.invoke(status).output))
     else:
@@ -37,7 +50,8 @@ def valid_data():
     return SimpleNamespace(
         test_settings_id='2e4fb86c-ac70-459d-a452-8fa2e9101d16',
         test_result_id='184e0b68-eb4e-4368-9f6e-a56fd9c177cf',
-        test_result_id_to_delete = '07040512-23ca-4d9c-bdb7-a64450ea5949'
+        test_result_id_to_delete='07040512-23ca-4d9c-bdb7-a64450ea5949',
+        default_workspace_id='5e3acde2e860a132744ca916'
     )
 
 

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -90,7 +90,7 @@ def generate_test_result_name():
     return 'Test result CLI %s' % datetime.utcnow().strftime('%b %d %H:%M:%S.%f')[:-3]
 
 
-def mock_login_get_urls(monkeypatch):
+def mock_login_get_urls(monkeypatch, version='2.5.0'):
     if monkeypatch is not None:
         monkeypatch.setattr(user_data, '__compute_version_and_path',
-                            lambda: user_data.get_user_data().set_url('http://front', 'http://files', '1.2.3'))
+                            lambda: user_data.get_user_data().set_url('http://front.com:8081/nlw', 'http://files.com:8082', version))

--- a/tests/neoload_cli_lib/test_user_data.py
+++ b/tests/neoload_cli_lib/test_user_data.py
@@ -37,6 +37,7 @@ class TestUserData:
             user_data.get_user_data()
         assert 'You are\'nt logged. Please use command "neoload login" first' in str(context.value)
 
+    @pytest.mark.usefixtures('neoload_login')
     def test_is_version_lower_than(selfself):
         user_data.set_meta('version', 'SaaS')
         assert user_data.is_version_lower_than('2.5.1') is False

--- a/tests/neoload_cli_lib/test_user_data.py
+++ b/tests/neoload_cli_lib/test_user_data.py
@@ -36,3 +36,27 @@ class TestUserData:
         with pytest.raises(click.ClickException) as context:
             user_data.get_user_data()
         assert 'You are\'nt logged. Please use command "neoload login" first' in str(context.value)
+
+    def test_is_version_lower_than(selfself):
+        user_data.set_meta('version', 'SaaS')
+        assert user_data.is_version_lower_than('2.5.1') is False
+        user_data.set_meta('version', '2.5.1')
+        assert user_data.is_version_lower_than('2.5.1') is False
+        user_data.set_meta('version', '2.6.1')
+        assert user_data.is_version_lower_than('2.5.1') is False
+        user_data.set_meta('version', '12.34.56')
+        assert user_data.is_version_lower_than('10.0.0') is False
+        user_data.set_meta('version', '123.456.789')
+        assert user_data.is_version_lower_than('123.0.0') is False
+
+        user_data.set_meta('version', 'legacy')
+        assert user_data.is_version_lower_than('2.5.1') is True
+        user_data.set_meta('version', '2.5.1')
+        assert user_data.is_version_lower_than('2.6.1') is True
+        user_data.set_meta('version', '123.456.789')
+        assert user_data.is_version_lower_than('124.1.1') is True
+
+        user_data.set_meta('version', '2.0.0')
+        assert user_data.is_version_lower_than('legacy') is False
+        user_data.set_meta('version', '2.0.0')
+        assert user_data.is_version_lower_than('SaaS') is True


### PR DESCRIPTION
This pull request have one feature by commit
 * Clean shadow endpoint : Call the function 'get_nlweb_information' to get urls and version. If this URL does not return Http200, then use the "old" way to get urls.

 * Add a "workspaces" command ; add a "--workspace" option to the login command. These new features works only for NLW>=2.5.0 (otherwise an error is thrown)

* For all commands, the base URL is defined depending ont the NLW version and if a workspace is set. (/v2 or /v3 or /v3/workspace/{workspaceId})

* On the login command, display a clear error instead of a stacktrace when bad token or bad URL or frontend URL

* Small fix on the command logs-url