### PR TITLE
Add 'cur' pseudonym support to logs-url command

### DIFF
--- a/neoload/commands/logs_url.py
+++ b/neoload/commands/logs_url.py
@@ -5,11 +5,28 @@ import click
 from commands import test_results
 from neoload_cli_lib import user_data, tools
 
+from neoload_cli_lib.name_resolver import Resolver
+from neoload_cli_lib import rest_crud, user_data
+
+__endpoint = "/test-results"
+
+__resolver = Resolver(__endpoint, rest_crud.base_endpoint_with_workspace)
+
+meta_key = 'result id'
 
 @click.command()
 @click.argument('name', type=str)
 def cli(name):
     """get logs url of a test result managed by NeoLoad Web"""
+
+    if name == "cur":
+        name = user_data.get_meta(meta_key)
+    is_id = tools.is_id(name)
+
+    __id = tools.get_id(name, __resolver, is_id)
+
+    if not __id:
+        __id = user_data.get_meta_required(meta_key)
 
     print(get_url(name))
 


### PR DESCRIPTION
In support of Ideas request http://ideas.neotys.com/feedbacks/181051-publish-reporting-url-nlweb#comment_402135

Added 'cur' lookup logic to logs-url command so that it's easy to report in the context of a CI pipeline.

Added tag 1.1.5rc1 to pre-release to Pypi