### PR TITLE
Filtering for ls-related commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,10 +164,19 @@ neoload stop             # Send the stop signal to the test and wait until it en
 ## View results
 ```
 Usage: neoload test-results [OPTIONS] [[ls|summary|junitsla|put|delete|use]] [NAME]
+neoload test-results ls                 # Lists test results                                            .
+neoload test-results use                # Remember the test result you want to work on.                           .
 neoload test-results summary            # The Json result summary, with SLAs
 neoload test-results junitsla           # Output the summary in a JUnit xml file
 ```
 Metadata on a test can be modified after the test is complete, such as name, description, and status.\
+
+To filter test results based on project, scenario, or status:
+```
+neoload test-results --filter "project=MyProject;scenario=fullTest" ls
+neoload test-results --filter "status=TERMINATED|qualityStatus=FAILED" ls
+```
+NOTE: you can use either a semicolon OR a pipe, but not both interchangeably in the same filter.
 
 To work with a specific test result and be able to chain commands
 ```

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -53,7 +53,7 @@ def cli(command, name, rename, description, quality_status, junit_file, file, fi
     is_id = tools.is_id(name)
     # avoid to make two requests if we have not id.
     if command == "ls":
-        tools.ls(name, is_id, __resolver, filter)
+        tools.ls(name, is_id, __resolver, filter, ['project','status','author'])
         return
 
     __id = tools.get_id(name, __resolver, is_id)

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -33,7 +33,8 @@ def load_from_file(file):
 @click.option('--quality-status', 'quality_status', type=click.Choice(['PASSED', 'FAILED']), help="")
 @click.option('--junit-file', 'junit_file', default="junit-sla.xml", help="Output the junit sla report to this path")
 @click.option('--file', type=click.File('r'), help="Json file with the data to be sent to the API.")
-def cli(command, name, rename, description, quality_status, junit_file, file):
+@click.option('--filter', help="Filter test results by project, scenario, and other fields")
+def cli(command, name, rename, description, quality_status, junit_file, file, filter):
     """
     ls       # Lists test results                                            .
     summary  # Display a summary of the result : SLAs and statistics         .
@@ -52,7 +53,7 @@ def cli(command, name, rename, description, quality_status, junit_file, file):
     is_id = tools.is_id(name)
     # avoid to make two requests if we have not id.
     if command == "ls":
-        tools.ls(name, is_id, __resolver)
+        tools.ls(name, is_id, __resolver, filter)
         return
 
     __id = tools.get_id(name, __resolver, is_id)

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -33,7 +33,7 @@ def load_from_file(file):
 @click.option('--quality-status', 'quality_status', type=click.Choice(['PASSED', 'FAILED']), help="")
 @click.option('--junit-file', 'junit_file', default="junit-sla.xml", help="Output the junit sla report to this path")
 @click.option('--file', type=click.File('r'), help="Json file with the data to be sent to the API.")
-@click.option('--filter', help="Filter test results by project, scenario, and other fields")
+@click.option('--filter', help="Filter test results by fields. Mostly used filters are : name, scenario, project, status.")
 def cli(command, name, rename, description, quality_status, junit_file, file, filter):
     """
     ls       # Lists test results                                            .

--- a/neoload/neoload_cli_lib/filtering.py
+++ b/neoload/neoload_cli_lib/filtering.py
@@ -11,20 +11,14 @@ def clear_filter():
     last_filter_spec = None
     last_allowed_api_query_params = None
 
-def stuff_current_filters(params):
+def parse_filters(params):
     global last_filter_spec, last_allowed_api_query_params
     filter_spec = last_filter_spec
     allowed_api_query_params = last_allowed_api_query_params
 
     filters = parse_filter_spec(filter_spec)
 
-    if allowed_api_query_params is not None and isinstance(allowed_api_query_params, list):
-        for key in allowed_api_query_params:
-            if key in filters: # move key/value from filter to query params
-                params[key] = filters[key]
-                del filters[key]
-
-    return (params, filters)
+    return (allowed_api_query_params, filters)
 
 def parse_filter_spec(filter_spec):
     ret = {}
@@ -40,8 +34,8 @@ def parse_filter_spec(filter_spec):
     return ret
 
 def remove_by_last_filter(all_entities):
-    (params,filters) = stuff_current_filters({})
-    return list(filter(lambda entity: entity_matches_all_filters(entity, filters), all_entities))
+    (allowed_api_query_params,filters) = parse_filters({})
+    return list(filter(lambda entity,fils=filters: entity_matches_all_filters(entity, fils), all_entities))
 
 def entity_matches_all_filters(entity, filters):
     for key in filters.keys():

--- a/neoload/neoload_cli_lib/filtering.py
+++ b/neoload/neoload_cli_lib/filtering.py
@@ -1,0 +1,56 @@
+import re
+
+last_filter_spec = None
+last_input_params = None
+def set_filter(filter_spec, input_params):
+    global last_filter_spec, last_input_params
+    last_filter_spec = filter_spec
+    last_input_params = input_params
+def clear_filter():
+    global last_filter_spec, last_input_params
+    last_filter_spec = None
+    last_input_params = None
+
+def stuff_current_filters(params):
+    global last_filter_spec, last_input_params
+    filter_spec = last_filter_spec
+    input_params = last_input_params
+
+    filters = {}
+    if filter_spec is not None and len(filter_spec)>0:
+        filters = parse_filter_spec(filter_spec)
+
+    if input_params is not None and isinstance(input_params, list):
+        for key in input_params:
+            if key in filters: # move key/value from filter to query params
+                params[key] = filters[key]
+                del filters[key]
+
+    return (params, filters)
+
+def parse_filter_spec(filter_spec):
+    ret = {}
+    if filter_spec is not None:
+        filter_parts = filter_spec.split("|" if "|" in filter_spec else ";")
+        for part in filter_parts:
+            subparts = part.split("=")
+            key = subparts[0]
+            value = "=".join(subparts[1:])
+            ret[key] = value
+
+    return ret
+
+def remove_by_last_filter(all_entities):
+    (params,filters) = stuff_current_filters({})
+    return list(filter(lambda entity: entity_matches_all_filters(entity, filters), all_entities))
+
+def entity_matches_all_filters(entity, filters):
+    for key in filters.keys():
+        if key in entity:
+            find_re = filters[key].replace("*",".+")
+            in_val = entity[key]
+            if not re.search(find_re, in_val):
+                return False
+        else:
+            return False
+    return True

--- a/neoload/neoload_cli_lib/filtering.py
+++ b/neoload/neoload_cli_lib/filtering.py
@@ -1,27 +1,25 @@
 import re
 
 last_filter_spec = None
-last_input_params = None
-def set_filter(filter_spec, input_params):
-    global last_filter_spec, last_input_params
+last_allowed_api_query_params = None
+def set_filter(filter_spec, allowed_api_query_params):
+    global last_filter_spec, last_allowed_api_query_params
     last_filter_spec = filter_spec
-    last_input_params = input_params
+    last_allowed_api_query_params = allowed_api_query_params
 def clear_filter():
-    global last_filter_spec, last_input_params
+    global last_filter_spec, last_allowed_api_query_params
     last_filter_spec = None
-    last_input_params = None
+    last_allowed_api_query_params = None
 
 def stuff_current_filters(params):
-    global last_filter_spec, last_input_params
+    global last_filter_spec, last_allowed_api_query_params
     filter_spec = last_filter_spec
-    input_params = last_input_params
+    allowed_api_query_params = last_allowed_api_query_params
 
-    filters = {}
-    if filter_spec is not None and len(filter_spec)>0:
-        filters = parse_filter_spec(filter_spec)
+    filters = parse_filter_spec(filter_spec)
 
-    if input_params is not None and isinstance(input_params, list):
-        for key in input_params:
+    if allowed_api_query_params is not None and isinstance(allowed_api_query_params, list):
+        for key in allowed_api_query_params:
             if key in filters: # move key/value from filter to query params
                 params[key] = filters[key]
                 del filters[key]
@@ -30,7 +28,8 @@ def stuff_current_filters(params):
 
 def parse_filter_spec(filter_spec):
     ret = {}
-    if filter_spec is not None:
+
+    if filter_spec is not None and len(filter_spec)>0:
         filter_parts = filter_spec.split("|" if "|" in filter_spec else ";")
         for part in filter_parts:
             subparts = part.split("=")
@@ -47,7 +46,7 @@ def remove_by_last_filter(all_entities):
 def entity_matches_all_filters(entity, filters):
     for key in filters.keys():
         if key in entity:
-            find_re = filters[key].replace("*",".+")
+            find_re = filters[key]
             in_val = entity[key]
             if not re.search(find_re, in_val):
                 return False

--- a/neoload/neoload_cli_lib/name_resolver.py
+++ b/neoload/neoload_cli_lib/name_resolver.py
@@ -9,7 +9,7 @@ class Resolver:
         self.__map = {}
 
     def __fill_map(self, ws, name=None):
-        all_element = rest_crud.get_with_pagination(self.get_endpoint())
+        all_element = rest_crud.get_with_pagination(self.get_endpoint(), api_query_params=None)
         json = None
         ws_map = {}
         self.__map[ws] = ws_map

--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -46,7 +46,12 @@ def get_with_pagination(endpoint: str, page_size=200):
         'offset': 0
     }
 
-    (params,filters) = filtering.stuff_current_filters(params)
+    (allowed_api_query_params,filters) = filtering.parse_filters(params)
+    if allowed_api_query_params is not None and isinstance(allowed_api_query_params, list):
+        for key in allowed_api_query_params:
+            if key in filters: # move key/value from filter to query params
+                params[key] = filters[key]
+                del filters[key]
 
     # Get first page
     all_entities = get(endpoint, params)

--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -39,19 +39,13 @@ def base_endpoint():
     return "v2" if user_data.is_version_lower_than('2.5.0') else "v3"
 
 
-def get_with_pagination(endpoint: str, page_size=200):
+def get_with_pagination(endpoint: str, page_size=200, api_query_params=None):
 
     params = {
         'limit': page_size,
         'offset': 0
     }
-
-    (allowed_api_query_params,filters) = filtering.parse_filters(params)
-    if allowed_api_query_params is not None and isinstance(allowed_api_query_params, list):
-        for key in allowed_api_query_params:
-            if key in filters: # move key/value from filter to query params
-                params[key] = filters[key]
-                del filters[key]
+    params.update(api_query_params or {})   # Add query params for filters
 
     # Get first page
     all_entities = get(endpoint, params)
@@ -64,8 +58,6 @@ def get_with_pagination(endpoint: str, page_size=200):
             break
         all_entities += entities
         params['offset'] += page_size
-
-    all_entities = filtering.remove_by_last_filter(all_entities)
 
     return all_entities
 

--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -6,9 +6,8 @@ import sys
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 from tqdm import tqdm
 import copy
-import re
 
-from neoload_cli_lib import user_data, cli_exception, tools
+from neoload_cli_lib import user_data, cli_exception, tools, filtering
 from version import __version__
 
 __current_command = ""
@@ -40,22 +39,14 @@ def base_endpoint():
     return "v2" if user_data.is_version_lower_than('2.5.0') else "v3"
 
 
-def get_with_pagination(endpoint: str, page_size=200, filter_spec=None, input_params=None):
-
-    filters = {}
-    if filter_spec is not None and len(filter_spec)>0:
-        filters = parse_filter_spec(filter_spec)
+def get_with_pagination(endpoint: str, page_size=200):
 
     params = {
         'limit': page_size,
         'offset': 0
     }
 
-    if input_params is not None and isinstance(input_params, list):
-        for key in input_params:
-            if key in filters: # move key/value from filter to query params
-                params[key] = filters[key]
-                del filters[key]
+    (params,filters) = filtering.stuff_current_filters(params)
 
     # Get first page
     all_entities = get(endpoint, params)
@@ -69,32 +60,12 @@ def get_with_pagination(endpoint: str, page_size=200, filter_spec=None, input_pa
         all_entities += entities
         params['offset'] += page_size
 
-    all_entities = list(filter(lambda entity: entity_matches_all_filters(entity, filters), all_entities))
+    all_entities = filtering.remove_by_last_filter(all_entities)
 
     return all_entities
 
-def entity_matches_all_filters(entity, filters):
-    for key in filters.keys():
-        if key in entity:
-            find_re = filters[key].replace("*",".+")
-            in_val = entity[key]
-            if not re.search(find_re, in_val):
-                return False
-        else:
-            return False
-    return True
 
-def parse_filter_spec(filter_spec):
-    ret = {}
-    if filter_spec is not None:
-        filter_parts = filter_spec.split("|" if "|" in filter_spec else ";")
-        for part in filter_parts:
-            subparts = part.split("=")
-            key = subparts[0]
-            value = "=".join(subparts[1:])
-            ret[key] = value
 
-    return ret
 
 
 def get(endpoint: str, params=None):

--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -38,7 +38,7 @@ def base_endpoint():
     return "v2" if user_data.is_version_lower_than('2.5.0') else "v3"
 
 
-def get_with_pagination(endpoint: str, page_size=200):
+def get_with_pagination(endpoint: str, page_size=200, filter=None):
     params = {
         'limit': page_size,
         'offset': 0

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -90,12 +90,12 @@ def get_named_or_id(name, is_id_, resolver):
     return rest_crud.get(endpoint + "/" + name)
 
 
-def ls(name, is_id_, resolver, filter):
+def ls(name, is_id_, resolver, filter_spec=None, input_params=None):
     endpoint = resolver.get_endpoint()
     if name:
         get_id_and_print_json(get_named_or_id(name, is_id_, resolver))
     else:
-        print_json(rest_crud.get_with_pagination(endpoint=endpoint, filter=filter))
+        print_json(rest_crud.get_with_pagination(endpoint=endpoint, filter_spec=filter_spec, input_params=input_params))
 
 
 def delete(endpoint, id_data, kind):

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -90,12 +90,12 @@ def get_named_or_id(name, is_id_, resolver):
     return rest_crud.get(endpoint + "/" + name)
 
 
-def ls(name, is_id_, resolver):
+def ls(name, is_id_, resolver, filter):
     endpoint = resolver.get_endpoint()
     if name:
         get_id_and_print_json(get_named_or_id(name, is_id_, resolver))
     else:
-        print_json(rest_crud.get_with_pagination(endpoint))
+        print_json(rest_crud.get_with_pagination(endpoint=endpoint, filter=filter))
 
 
 def delete(endpoint, id_data, kind):

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -95,13 +95,9 @@ def ls(name, is_id_, resolver, filter_spec=None, allowed_api_query_params=None):
     if name:
         get_id_and_print_json(get_named_or_id(name, is_id_, resolver))
     else:
-        filtering.set_filter(filter_spec, allowed_api_query_params)
-        print_json(
-            filtering.remove_by_last_filter(
-                rest_crud.get_with_pagination(endpoint)
-            )
-        )
-        filtering.clear_filter()
+        (api_query_params, cli_params) = filtering.parse_filters(filter_spec, allowed_api_query_params)
+        all_entities = rest_crud.get_with_pagination(endpoint, api_query_params=api_query_params)
+        print_json(filtering.remove_by_filter(all_entities, cli_params))
 
 
 def delete(endpoint, id_data, kind):

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -8,7 +8,7 @@ import click
 from click import ClickException
 from termcolor import cprint
 
-from neoload_cli_lib import rest_crud, user_data
+from neoload_cli_lib import rest_crud, user_data, filtering
 
 __regex_id = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 __regex_mongodb_id = re.compile('[a-f\\d]{24}', re.IGNORECASE)
@@ -95,7 +95,13 @@ def ls(name, is_id_, resolver, filter_spec=None, input_params=None):
     if name:
         get_id_and_print_json(get_named_or_id(name, is_id_, resolver))
     else:
-        print_json(rest_crud.get_with_pagination(endpoint=endpoint, filter_spec=filter_spec, input_params=input_params))
+        filtering.set_filter(filter_spec, input_params)
+        print_json(
+            filtering.remove_by_last_filter(
+                rest_crud.get_with_pagination(endpoint)
+            )
+        )
+        filtering.clear_filter()
 
 
 def delete(endpoint, id_data, kind):

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -90,12 +90,12 @@ def get_named_or_id(name, is_id_, resolver):
     return rest_crud.get(endpoint + "/" + name)
 
 
-def ls(name, is_id_, resolver, filter_spec=None, input_params=None):
+def ls(name, is_id_, resolver, filter_spec=None, allowed_api_query_params=None):
     endpoint = resolver.get_endpoint()
     if name:
         get_id_and_print_json(get_named_or_id(name, is_id_, resolver))
     else:
-        filtering.set_filter(filter_spec, input_params)
+        filtering.set_filter(filter_spec, allowed_api_query_params)
         print_json(
             filtering.remove_by_last_filter(
                 rest_crud.get_with_pagination(endpoint)

--- a/tests/commands/test_results/test_result_ls.py
+++ b/tests/commands/test_results/test_result_ls.py
@@ -31,6 +31,16 @@ class TestResultLs:
         assert json_result['name'] is not None
         assert json_result['description'] is not None
 
+    def test_list_filter(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v2/test-results',
+                     '[{"id":"someId", "name":"test-name", "description":".... "},'
+                     '{"id":"someId", "name":"test-name-2", "description":".... "}]')
+        result_ls = runner.invoke(results, ['ls', '--filter','name=test-name-2'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert len(json_result) == 1
+
     def test_error_not_logged_in(self):
         runner = CliRunner()
         result_logout = runner.invoke(logout)

--- a/tests/commands/test_results/test_result_ls.py
+++ b/tests/commands/test_results/test_result_ls.py
@@ -41,6 +41,53 @@ class TestResultLs:
         json_result = json.loads(result_ls.output)
         assert len(json_result) == 1
 
+    def test_list_filter_unknown(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v2/test-results',
+                     '[{"id":"someId", "name":"test-name", "description":".... "},'
+                     '{"id":"someId", "name":"test-name-2", "description":".... "}]')
+        result_ls = runner.invoke(results, ['ls', '--filter','unknown=test-name-2'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert len(json_result) == 0
+
+    def test_list_filter_regex(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v2/test-results',
+                     '[{"id":"someId1", "name":"test-name", "description":".... "},'
+                     '{"id":"someId2", "name":"test-name-0", "description":"I\'m good !!"},'
+                     '{"id":"someId3", "name":"test-name-2", "description":".... "}]')
+        result_ls = runner.invoke(results, ['ls', '--filter','name=test-name-[0-9]'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert len(json_result) == 2
+        assert json_result[0]['id'] == "someId2"
+        assert json_result[1]['id'] == "someId3"
+
+    def test_list_filter_regex_wildcard(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v2/test-results',
+                     '[{"id":"someId1", "name":"test-name", "description":".... "},'
+                     '{"id":"someId2", "name":"test-name-2", "description":".... "}]')
+        result_ls = runner.invoke(results, ['ls', '--filter','name=test-name.*'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert len(json_result) == 2
+        assert json_result[0]['id'] == "someId1"
+        assert json_result[1]['id'] == "someId2"
+
+    def test_list_filter_multiple(self, monkeypatch, valid_data):
+        runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v2/test-results',
+                     '[{"id":"someId1", "name":"test-name", "description":".... "},'
+                     '{"id":"someId2", "name":"test-name-1", "description":"I\'m bad"},'
+                     '{"id":"someId3", "name":"test-name-2", "description":"I\'m good !!"}]')
+        result_ls = runner.invoke(results, ['ls', '--filter','name=test-name-[0-9];description=^I\'m good*'])
+        assert_success(result_ls)
+        json_result = json.loads(result_ls.output)
+        assert len(json_result) == 1
+        assert json_result[0]['id'] == "someId3"
+
     def test_error_not_logged_in(self):
         runner = CliRunner()
         result_logout = runner.invoke(logout)

--- a/tests/helpers/test_utils.py
+++ b/tests/helpers/test_utils.py
@@ -11,7 +11,7 @@ def assert_success(result):
 
 
 def mock_api_get_with_pagination(monkeypatch, endpoint, json_result):
-    __mock_api_without_data(monkeypatch, 'get_with_pagination', endpoint, json_result)
+    __mock_api_without_data_two_args(monkeypatch, 'get_with_pagination', endpoint, json_result)
 
 
 def mock_api_get(monkeypatch, endpoint, json_result):
@@ -46,6 +46,13 @@ def __mock_api_without_data(monkeypatch, method, endpoint, json_result):
     if monkeypatch is not None:
         monkeypatch.setattr(rest_crud, method,
                             lambda actual_endpoint: __return_json(actual_endpoint, endpoint, json_result))
+        print('Mock %s %s to return %s' % (method.upper(), endpoint, json_result))
+
+
+def __mock_api_without_data_two_args(monkeypatch, method, endpoint, json_result):
+    if monkeypatch is not None:
+        monkeypatch.setattr(rest_crud, method,
+                            lambda actual_endpoint, api_query_params: __return_json(actual_endpoint, endpoint, json_result))
         print('Mock %s %s to return %s' % (method.upper(), endpoint, json_result))
 
 

--- a/tests/neoload_cli_lib/test_filtering.py
+++ b/tests/neoload_cli_lib/test_filtering.py
@@ -1,0 +1,19 @@
+from neoload_cli_lib import filtering
+
+
+class TestFiltering:
+    def test_parse_filters(self):
+        (api_query_params, cli_params) = filtering.parse_filters('name=toto;description=a word', ['name'])
+        assert len(api_query_params) == 1
+        assert api_query_params['name'] == 'toto'
+        assert len(cli_params) == 1
+        assert cli_params['description'] == 'a word'
+
+    def test_remove_by_filter(self):
+        cli_params = {'description': 'a word'}
+        all_elements = [{"id": "someId", "name": "elementWithouDescription"},
+                        {"id": "someId", "name": "toto", "description": "a word"},
+                        {"id": "someId", "name": "notMe", "description": ".... "}]
+        filtered_elements = filtering.remove_by_filter(all_elements, cli_params)
+        assert len(filtered_elements) == 1
+        assert filtered_elements[0] == {"id": "someId", "name": "toto", "description": "a word"}


### PR DESCRIPTION
## What?
Update to get_with_pagination and ls functions to support more precise filtering of JSON results from the REST API.

## Why?
In a real system, the 'test-results ls' command may come back with thousands of results, which is typically not the intent of the calling process. Usually, there is more of a precise context for what is being searched for, such as test results by project name, scenario, status, or qualityStatus. Therefore, and easy way to filter output, and where possible do this by providing the API endpoint matching parameters to let the API do the work, is needed.

## How?
Update existing logic to include --filter "project=MyProject;scenario=MyScenario", such that the project parameter is used in the API call. Other parameters, such as the scenario value (which isn't currently supported as an API param) should be used after pagination against resulting entities whose properties identified by the key values match their corresponding filter values. Values can use regex or a wildcard-star character. Multiple filters shall be delimited by the pipe (priority) or semicolon character and shall be treated as AND exclusive (multiple filters must all be matched).

## Testing
Tested locally against SaaS CPV data and added tests/commands/test_results/test_result_ls.py::TestResultLs::test_list_filter

## Additional Notes
Due to the nature of monkeypatch and optional parameter support, in order to remain compatible to both real and mock fixtures, this had to be implemented to use filtering.set_filter before and filtering.clear_filter after the call. Use of filtering.remove_by_last_filter in the tools.ls command ensures that tests also exercise the post-processing filters, not simply when real API data is used.