### PR TITLE
Version management on pypi in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+## 1.1.5 (2020-11-25)
+- [Feature] Filtering for ls-related commands
+- [Feature] Progress bar at project upload
+- [Feature] Add Bamboo pipeline example
+- [Fix] Global SLA are not displayed in Junit report
+
+## 1.1.4 (2020-09-25)
+- [Feature] Capability to manage self signed certificate
+- [Feature] .nlignore files allow you to specify yaml files not to upload (ex: .gitlab-ci.yaml)
+- [Feature] Add AWS pipeline example
+- [Feature] Add 'cur' pseudonym support to logs-url command
+
+## 1.1.0 (2020-08-11)
+- [Feature] Workspace command and support workspaces at login
+- [Feature] Fastfail command and the jenkins example for fastfail
+- [Improvement] Jenkins pipeline example and many other small improvements
+- [Improvement] Better error message for bad NL url
+- [Fix] Handling of pagination by API for ls subcommand
+- [Fix] Support "between" threshold in SLA</li></ul>
+
+## 1.0.1 (2020-06-25)
+- [Fix] Set required versions for setup
+- [Fix] error when displaying results at the end of the test
+
+## 1.0.0 (2020-05-14)
+Initial version with commands and sub-commands
+
+## 0.4.6 (2020-05-09)
+Experimental version

--- a/README.md
+++ b/README.md
@@ -381,8 +381,10 @@ Status of IDE / editor integrations
  | PyCharm |      [x]      |      [x]      | Mark 'neoload' directory as "Sources Root" |
 
 ## Contributing
-Feel free to fork this repo, make changes, *test locally*, and create a pull request. As part of your testing, you should run the built-in test suite with the following command:
+Feel free to fork this repo, make changes, *test locally*, and create a pull request.
 
+#### Tests
+As part of your testing, you should run the built-in test suite with the following command: \
 NOTE: for testing from Mac, please change the PYTHONPATH separators below to colons (:) instead of semicolons (;).
 
 ```
@@ -398,3 +400,18 @@ Additionally, any contributions to the DSL validation functionality, such as on 
 ./tests/neoload_projects/yaml_variants/validate_all.sh
 ```
 This command executes a number of NEGATIVE tests to prove that changes to the JSON schema or validation process produce failures when their input is malformed in very specific ways (common mistakes).
+
+#### Version management on pypi
+Suppose X, Y, Z and N are integers, versions will be named as following on pypi: \
+**Final release version = X.Y.Z** Example *1.4.0* Install it with ```pip install neoload``` \
+**Release candidate version = X.Y.ZrcN** Example *1.5.0rc1* for the next candidate version. Install it with ```pip install neoload --pre``` \
+**Development versions = X.Y.Z.devN** Example *1.4.0.dev1* for a development version based on the final release 1.4.0. Install it with ```pip install neoload==1.4.0.dev1```
+
+Release candidate version contains all features planned and in testing by Quality Assurance team.
+
+Development versions may contains work not planned by R&D and not tested by Quality Assurance team. They should always be based on an official release, not on the next release.
+
+**Increment policy:**
+ - Minor version increment when major feature, for example new top-level command
+ - Fix version increment when executable changes, for example fixing an existing feature, or update a subcommand to an existing top-level command or update options to an existing command
+ - No release needed when the executable is not modified, for example when updating the following: automated CI tests, unit tests, README, Pipeline examples, report templates...


### PR DESCRIPTION
See [Jira task LOAD-22495](https://neotys.atlassian.net/browse/LOAD-22495) CLI : publish nonRC release on Pypi

This request describes how we can handle version numbering on pypi to prevent users that install CLI with "pip install --pre" to have features added/removed during development process.
