### PR TITLE
Add github actions for package and release on pypi

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.8']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+        python -m pip install coverage
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Test with pytest
+      run: |
+        PYTHONPATH="neoload" coverage3 run -m pytest
+        coverage3 xml
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -1,0 +1,30 @@
+name: Python release
+
+on:
+  push:
+    tags: [ '**' ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Prepare distribution
+      run: |
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NeoLoad CLI [![Build Status](https://travis-ci.org/Neotys-Labs/neoload-cli.svg?branch=master)](https://travis-ci.org/Neotys-Labs/neoload-cli)
+# NeoLoad CLI [![Build Status](https://github.com/Neotys-Labs/neoload-cli/workflows/Python%20package/badge.svg?branch=master)](https://github.com/Neotys-Labs/neoload-cli/actions?query=workflow%3A%22Python+package%22+branch%3A%22master%22)
 
 ## Overview
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,4 @@
+sonar.organization=neotys
 sonar.projectKey=neoload-cli
 sonar.language=py
 sonar.exclusions=tests/**, examples/**


### PR DESCRIPTION
## What?
New Continuous integration environment in Github.

## Why?
Because our CI travis.org must be migrated and jobs are queued for a long time.

## How?
2 new pipelines :
 - "Python package" to build, test and apply sonar analysis. Triggered at each push on a branch and each pull request to master.
 - "Python release" to package and upload on pypi. Triggered at each push a new tag.

## Testing
This pull request should be built.

2 versions "1.1.5.dev1" and  "1.1.5.dev2" has been published on pypi to test the pipeline release.

## Additional Notes
⚠️ ⚠️ **Before merging we should disable travis automatic builds when we push on github.**