### PR TITLE
Define test requirements in a separate file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 install:
   - pip install .
   - pip install coverage
+  - pip install -r requirements.txt
 # command to run tests
 script:
   - PYTHONPATH="neoload" coverage3 run -m pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-datafiles
+lxml
+xmldiff

--- a/setup.py
+++ b/setup.py
@@ -37,16 +37,13 @@ setup(
         'requests',
         'jsonschema',
         'PyYAML>=5',
-        'pytest',
-        'pytest-datafiles',
         'junit_xml',
         'termcolor',
         'coloredlogs',
         'gitignore_parser',
         'tqdm',
         'requests_toolbelt',
-        'urllib3',
-        'xmldiff'
+        'urllib3'
     ],
     long_description_content_type='text/markdown',
     long_description=long_description


### PR DESCRIPTION
## What?
Move dependencies not required by neoload command out of setup.py. For example test dependencies.

## Why?
Because xmldiff requires xmlib which in-turn requires C bound libxml2 and libxslt requirements (not in the setup.py), my pip install has to run this on Mac:
`RUN apk add --update --no-cache g++ gcc libxml2-dev libxslt-dev python-dev libffi-dev openssl-dev make`

## How?
Test dependencies are declared in _requirements.txt_ and are installed in CI builds (travis and githubActions) with `pip install -r requirements.txt`

## Testing

## Additional Notes
