### PR TITLE
Retry after the specified delay when NLW rate limit is reached

### DIFF
--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -2,13 +2,26 @@ import logging
 import urllib.parse as urlparse
 
 import requests
-import sys
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 from tqdm import tqdm
-import copy
 
-from neoload_cli_lib import user_data, cli_exception, tools, filtering
+from neoload_cli_lib import user_data, cli_exception, tools
 from version import __version__
+
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+# Overrides parse_retry_after
+Retry.parse_retry_after = lambda self, retry_after: custom_parse_retry_after(retry_after)
+retry_strategy = Retry(
+    total=10,
+    status_forcelist=[429],
+    method_whitelist=["GET", "POST", "PUT", "PATCH", "DELETE"]
+)
+adapter = HTTPAdapter(max_retries=retry_strategy)
+http = requests.Session()
+http.mount("https://", adapter)
+http.mount("http://", adapter)
 
 __current_command = ""
 __current_sub_command = ""
@@ -26,6 +39,13 @@ def set_current_sub_command(command: str):
     __current_sub_command = command
 
 
+def custom_parse_retry_after(retry_after: str):
+    retry_after_seconds = int(retry_after) / 1000 if int(retry_after) > 0 else 0
+    logging.getLogger().warning(
+        f'WARNING: Too many requests, server rate limit reached. Retry in {retry_after_seconds} seconds.')
+    return retry_after_seconds
+
+
 def base_endpoint_with_workspace(ws=None):
     workspace_id = ws if ws else get_workspace()
     return "v2" if workspace_id is None else "v3/workspaces/" + workspace_id
@@ -40,12 +60,11 @@ def base_endpoint():
 
 
 def get_with_pagination(endpoint: str, page_size=200, api_query_params=None):
-
     params = {
         'limit': page_size,
         'offset': 0
     }
-    params.update(api_query_params or {})   # Add query params for filters
+    params.update(api_query_params or {})  # Add query params for filters
 
     # Get first page
     all_entities = get(endpoint, params)
@@ -62,22 +81,19 @@ def get_with_pagination(endpoint: str, page_size=200, api_query_params=None):
     return all_entities
 
 
-
-
-
 def get(endpoint: str, params=None):
     return __handle_error(get_raw(endpoint, params)).json()
 
 
 def get_raw(endpoint: str, params=None):
-    return requests.get(__create_url(endpoint), params, headers=__create_additional_headers(),
-                        verify=user_data.get_ssl_cert())
+    return http.get(__create_url(endpoint), params=params, headers=__create_additional_headers(),
+                    verify=user_data.get_ssl_cert())
 
 
 def post(endpoint: str, data):
     logging.debug(f'POST {endpoint} body={data}')
-    response = requests.post(__create_url(endpoint), headers=__create_additional_headers(), json=data,
-                             verify=user_data.get_ssl_cert())
+    response = http.post(__create_url(endpoint), headers=__create_additional_headers(), json=data,
+                         verify=user_data.get_ssl_cert())
     __handle_error(response)
     return response.json()
 
@@ -87,8 +103,8 @@ def __create_url_file_storage(endpoint):
 
 
 def get_from_file_storage(endpoint: str):
-    return __handle_error(requests.get(__create_url_file_storage(endpoint), headers=__create_additional_headers(),
-                                       verify=user_data.get_ssl_cert()))
+    return __handle_error(http.get(__create_url_file_storage(endpoint), headers=__create_additional_headers(),
+                                   verify=user_data.get_ssl_cert()))
 
 
 def post_binary_files_storage(endpoint: str, path, filename):
@@ -96,8 +112,8 @@ def post_binary_files_storage(endpoint: str, path, filename):
     multipart_form_data, bar = multipart_progress(path, filename)
     headers = __create_additional_headers()
     headers['Content-Type'] = multipart_form_data.content_type
-    response = requests.post(__create_url_file_storage(endpoint), headers=headers,
-                             data=multipart_form_data, verify=user_data.get_ssl_cert())
+    response = http.post(__create_url_file_storage(endpoint), headers=headers,
+                         data=multipart_form_data, verify=user_data.get_ssl_cert())
     if bar:
         bar.close()
     __handle_error(response)
@@ -122,23 +138,23 @@ def multipart_progress(path, filename):
 
 def put(endpoint: str, data):
     logging.debug(f'PUT {endpoint} body={data}')
-    response = requests.put(__create_url(endpoint), headers=__create_additional_headers(), json=data,
-                            verify=user_data.get_ssl_cert())
+    response = http.put(__create_url(endpoint), headers=__create_additional_headers(), json=data,
+                        verify=user_data.get_ssl_cert())
     __handle_error(response)
     return response.json()
 
 
 def patch(endpoint: str, data):
     logging.debug(f'PATCH {endpoint} body={data}')
-    response = requests.patch(__create_url(endpoint), headers=__create_additional_headers(), json=data,
-                              verify=user_data.get_ssl_cert())
+    response = http.patch(__create_url(endpoint), headers=__create_additional_headers(), json=data,
+                          verify=user_data.get_ssl_cert())
     __handle_error(response)
     return response.json()
 
 
 def delete(endpoint: str):
-    response = requests.delete(__create_url(endpoint), headers=__create_additional_headers(),
-                               verify=user_data.get_ssl_cert())
+    response = http.delete(__create_url(endpoint), headers=__create_additional_headers(),
+                           verify=user_data.get_ssl_cert())
     __handle_error(response)
     return response
 


### PR DESCRIPTION
## What?
Retry after the specified delay when NLW rate limit is reached

## Why?
NLW has an API rate limit currently at 300 calls per second per account. When the limit is reached, the CLI command fails... It should wait the specified amount of time then continue.

## How?
The "Requests" lib provides an out of the box solution for that.

## Testing
No unit tests for that since the requests are mocked.
 - Tested on a Development NLW with rate limit at 10/seconds and a for loop.
 - Tested by Paul with a "limit" command that sends a lot of API calls to exceed 300/min.
 - Tests with a real NLW environment (=openshift stack branch develop) are Success (laucnhed from Guillaume local environment)

## Additional Notes
NLW "Retry-after" header contains the number of **MILLISECONDS** to wait until the API is available again. The RFC standard is the number of **SECONDS** ! So we had to override the function "parse_retry_after".