### PR TITLE
Add 'pyparsing' to setup dependencies, tested/working in Jenkinsfile_…

### DIFF
--- a/examples/pipelines/jenkins/Jenkinsfile_dyninfra
+++ b/examples/pipelines/jenkins/Jenkinsfile_dyninfra
@@ -27,7 +27,7 @@ pipeline {
         }
         stage('Get NeoLoad project'){
             steps {
-                sh 'rm -f *.yml; https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/78a1366743b041088f357f0f702babfce5e55187/tests/neoload_projects/simpledemo.yml'
+                sh 'rm -f *.yml; wget https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/78a1366743b041088f357f0f702babfce5e55187/tests/neoload_projects/simpledemo.yml'
             }
         }
         stage('Prepare NeoLoad test') {

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'gitignore_parser',
         'tqdm',
         'requests_toolbelt',
-        'urllib3'
+        'urllib3',
+        'pyparsing'
     ],
     long_description_content_type='text/markdown',
     long_description=long_description


### PR DESCRIPTION
## What?
Add missing 'pyparsing' dependency for CI builds.

## Why?

Running the examples/docker pipelines in a vanilla DinD-based Jenkins instance produces the error ''. I believe it was introduced a while ago:

commit 062b02eaad9b333a3bfeb929e6a3452d4b83c6e2
Author: Guillaume BERT <guillaume.bert@neotys.com>
Date:   Thu Jul 23 12:17:59 2020 +0200

    Improve error message when trying to login to google.com

diff --git a/neoload/neoload_cli_lib/user_data.py b/neoload/neoload_cli_lib/user_data.py
--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -7,0 +7,1 @@
+from pyparsing import basestring


## How?
Add 'pyparsing' dependency to setup.py

## Testing
Ran standard tests locally and via internal Jenkins server.

## Additional Notes
Because this was introduced in June but we weren't regularly testing these pipelines, it was allowed in. I will be setting up Jenkins jobs for the pipeline examples to prove that they are working moving forward.