### PR TITLE
Remove pyparsing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Fix] removed pyparsing dep altogether; unnecessary
 
 ## 1.1.7 (2020-12-04)
+- [Fix] add retry logic to HTTP requesting
 - [Fix] add pyparsing dependency for Jenkins pipelines
 
 ## 1.1.6 (2020-12-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+
+## 1.1.8 (2020-12-04)
+- [Fix] removed pyparsing dep altogether; unnecessary
+
+## 1.1.7 (2020-12-04)
+- [Fix] add pyparsing dependency for Jenkins pipelines
+
 ## 1.1.6 (2020-12-03)
 - [Fix] remove useless dependency
 

--- a/examples/pipelines/jenkins/Jenkinsfile_dyninfra
+++ b/examples/pipelines/jenkins/Jenkinsfile_dyninfra
@@ -27,7 +27,7 @@ pipeline {
         }
         stage('Get NeoLoad project'){
             steps {
-                sh 'rm -f *.yml; https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/78a1366743b041088f357f0f702babfce5e55187/tests/neoload_projects/simpledemo.yml'
+                sh 'rm -f *.yml; wget https://raw.githubusercontent.com/Neotys-Labs/neoload-cli/78a1366743b041088f357f0f702babfce5e55187/tests/neoload_projects/simpledemo.yml'
             }
         }
         stage('Prepare NeoLoad test') {

--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -5,7 +5,6 @@ import sys
 import appdirs
 import requests
 import yaml
-from pyparsing import basestring
 from simplejson import JSONDecodeError
 
 from neoload_cli_lib import rest_crud, cli_exception, tools
@@ -61,7 +60,7 @@ def __compute_version_and_path():
 def get_file_storage_from_swagger():
     response = rest_crud.get_raw('explore/v2/swagger.yaml')
     spec = yaml.load(response.text, Loader=yaml.FullLoader)
-    if isinstance(spec, basestring) or 'paths' not in spec.keys():
+    if isinstance(spec, str) or 'basestring' in "{}".format(type(spec)) or 'paths' not in spec.keys():
         raise cli_exception.CliException(
             'Unable to reach Neoload Web API. Bad URL or bad swagger file at /explore/v2/swagger.yaml.'
         )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'gitignore_parser',
         'tqdm',
         'requests_toolbelt',
-        'urllib3'
+        'urllib3',
+        'pyparsing'
     ],
     long_description_content_type='text/markdown',
     long_description=long_description

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,7 @@ setup(
         'gitignore_parser',
         'tqdm',
         'requests_toolbelt',
-        'urllib3',
-        'pyparsing'
+        'urllib3'
     ],
     long_description_content_type='text/markdown',
     long_description=long_description


### PR DESCRIPTION
## What?
Complete removal of pyparsing dep, which is unecessary, but also has pre-releases that break backwards compat with basestring.

## Why?
It was breaking Jenkinsfile examples

## How?
Remove pyparsing dep in setup and in user_data.py in favor of type casting just in case old libraries (YAML) still produce the basestring type.

## Testing
Ran local test suite. Also locally messed up the swagger url to prove this works even when target is not valid YAML.

## Additional Notes
This kind of thing happens because setup.py (based on easy_install) doesn't differentiate pre-releases from official releases. We may want to seek a solution for this because I don't want our tools to break just because some random 3rd party library decides to push a pre-release that breaks compat. Maybe we move to explicit versions on every single dependency, and then once a quarter have some upgrade compat check process.