### PR TITLE
Add --save path argument to upload command

### DIFF
--- a/neoload/commands/project.py
+++ b/neoload/commands/project.py
@@ -1,14 +1,16 @@
 import click
 from commands import test_settings
 from neoload_cli_lib import user_data, tools, rest_crud, neoLoad_project
-
+import os
 
 @click.command()
 @click.argument("command", required=True, type=click.Choice(['up', 'upload', 'meta']))
 @click.option("--path", "-p", type=click.Path(exists=True), default='.',
               help="path of project folder, zip or yml file. . is default value")
+@click.option("--save", "-s", type=click.Path(exists=False),
+              help="Path to a (non-existent) file ending in .zip to preserve what was uploaded")
 @click.argument("name_or_id", type=str, required=False)
-def cli(command, name_or_id, path):
+def cli(command, name_or_id, path, save):
     """Upload and list scenario from settings"""
     if not name_or_id or name_or_id == "cur":
         name_or_id = user_data.get_meta(test_settings.meta_key)
@@ -17,7 +19,15 @@ def cli(command, name_or_id, path):
         name_or_id = test_settings.__resolver.resolve_name(name_or_id)
 
     if command[:2] == "up":
-        upload(path, name_or_id)
+        if save is not None:
+            save = os.path.abspath(save)
+            if not save.endswith(".zip"):
+                tools.system_exit({'code':1,'message':'If you specify a --save file, it must end with .zip'})
+                return
+            if os.path.exists(save):
+                tools.system_exit({'code':1,'message':"The --save file '{}' already exists! If you specify a --save file, it must not exist first. We wouldn't want to accidentally overwrite things, would we?".format(save)})
+                return
+        upload(path, name_or_id, save)
     elif command == "meta":
         meta_data(name_or_id)
     user_data.set_meta(test_settings.meta_key, name_or_id)
@@ -29,8 +39,8 @@ def cli(command, name_or_id, path):
 #TODO: spider through all YAML (as-code files)
 #TODO: fix validate to recurse through all includes; create unique file list map (avoid recursive references)
 
-def upload(path, settings_id):
-    neoLoad_project.upload_project(path, get_endpoint(settings_id))
+def upload(path, settings_id, save):
+    neoLoad_project.upload_project(path, get_endpoint(settings_id), save=save)
 
 
 def meta_data(setting_id):

--- a/neoload/commands/project.py
+++ b/neoload/commands/project.py
@@ -32,7 +32,7 @@ def cli(command, name_or_id, path, save):
 #TODO: fix validate to recurse through all includes; create unique file list map (avoid recursive references)
 
 def upload(path, settings_id, save):
-    neoLoad_project.upload_project(path, get_endpoint(settings_id), save=save)
+    neoLoad_project.upload_project(path, get_endpoint(settings_id), save)
 
 
 def meta_data(setting_id):

--- a/neoload/commands/project.py
+++ b/neoload/commands/project.py
@@ -19,14 +19,6 @@ def cli(command, name_or_id, path, save):
         name_or_id = test_settings.__resolver.resolve_name(name_or_id)
 
     if command[:2] == "up":
-        if save is not None:
-            save = os.path.abspath(save)
-            if not save.endswith(".zip"):
-                tools.system_exit({'code':1,'message':'If you specify a --save file, it must end with .zip'})
-                return
-            if os.path.exists(save):
-                tools.system_exit({'code':1,'message':"The --save file '{}' already exists! If you specify a --save file, it must not exist first. We wouldn't want to accidentally overwrite things, would we?".format(save)})
-                return
         upload(path, name_or_id, save)
     elif command == "meta":
         meta_data(name_or_id)

--- a/neoload/neoload_cli_lib/neoLoad_project.py
+++ b/neoload/neoload_cli_lib/neoLoad_project.py
@@ -6,7 +6,7 @@ import logging
 from gitignore_parser import parse_gitignore
 
 from neoload_cli_lib import rest_crud, tools, cli_exception
-from shutil import copyfile
+import shutil
 
 not_to_be_included = ['recorded-requests/', 'recorded-responses/', 'recorded-screenshots/', '.git/', '.svn/',
                       'results/',
@@ -24,22 +24,43 @@ def is_not_to_be_included(path: str, nl_ignore_matcher):
     return False
 
 
-def zip_dir(path):
+def zip_dir(path,save):
+
+    # validate save parameter, if provided, is a zip
+    if save is not None:
+        save = os.path.abspath(save)
+        if not save.endswith(".zip"):
+            raise cli_exception.CliException('If you specify where to save the zip file, it must end with .zip')
+
     # find and load .nlignore
     ignore_file = os.path.join(path, '.nlignore')
     nl_ignore_matcher = parse_gitignore(ignore_file) if os.path.exists(ignore_file) else None
 
-    temp_zip = tempfile.NamedTemporaryFile('w+b')
+    # always to work in a separate file, if save is provided, or otherwise
+    temp_zip = tempfile.NamedTemporaryFile('w+b',delete=False)
     ziph = zipfile.ZipFile(temp_zip, 'x', zipfile.ZIP_DEFLATED)
     for root, dirs, files in os.walk(path):
         for file in files:
             file_path = os.path.join(root, file)
             if not is_not_to_be_included(file_path, nl_ignore_matcher):
                 ziph.write(file_path, file_path.replace(str(path), ''))
-
     ziph.close()
-    temp_zip.seek(0)
-    return temp_zip
+
+    # by default we return the temp file
+    file_stream = temp_zip
+
+    # if save file specified, copy temp to the specified save file
+    if save is not None:
+        # only delete the specified save if temp was created
+        temp_zip.close()
+        shutil.move(temp_zip.name, save)
+        # return an open file stream to the new file specified by save
+        file_stream = open(save)
+
+    # always ensure that stream starts at beginning
+    file_stream.seek(0)
+
+    return file_stream
 
 
 def upload_project(path, endpoint, save=None):
@@ -48,20 +69,9 @@ def upload_project(path, endpoint, save=None):
         file = open(path, "b+r")
     else:
         filename += '.zip'
-        file = zip_dir(path)
-        save_local(file.name, save)
+        file = zip_dir(path,save)
 
     display_project(rest_crud.post_binary_files_storage(endpoint, file, filename))
-
-def save_local(source_path, save):
-    if save is not None:
-        save = os.path.abspath(save)
-        if not save.endswith(".zip"):
-            raise cli_exception.CliException('If you specify a --save file, it must end with .zip')
-        if os.path.exists(save):
-            raise cli_exception.CliException("The --save file '{}' already exists! If you specify a --save file, it must not exist first. We wouldn't want to accidentally overwrite things, would we?".format(save))
-        copyfile(source_path, save)
-
 
 def display_project(res):
     if 299 > res.status_code > 199:

--- a/neoload/neoload_cli_lib/neoLoad_project.py
+++ b/neoload/neoload_cli_lib/neoLoad_project.py
@@ -49,10 +49,18 @@ def upload_project(path, endpoint, save=None):
     else:
         filename += '.zip'
         file = zip_dir(path)
-        if save is not None and save.endswith(".zip") and not os.path.exists(save):
-            copyfile(file.name, save)
+        save_local(file.name, save)
 
     display_project(rest_crud.post_binary_files_storage(endpoint, file, filename))
+
+def save_local(source_path, save):
+    if save is not None:
+        save = os.path.abspath(save)
+        if not save.endswith(".zip"):
+            raise cli_exception.CliException('If you specify a --save file, it must end with .zip')
+        if os.path.exists(save):
+            raise cli_exception.CliException("The --save file '{}' already exists! If you specify a --save file, it must not exist first. We wouldn't want to accidentally overwrite things, would we?".format(save))
+        copyfile(source_path, save)
 
 
 def display_project(res):

--- a/neoload/neoload_cli_lib/neoLoad_project.py
+++ b/neoload/neoload_cli_lib/neoLoad_project.py
@@ -6,6 +6,7 @@ import logging
 from gitignore_parser import parse_gitignore
 
 from neoload_cli_lib import rest_crud, tools, cli_exception
+from shutil import copyfile
 
 not_to_be_included = ['recorded-requests/', 'recorded-responses/', 'recorded-screenshots/', '.git/', '.svn/',
                       'results/',
@@ -41,13 +42,16 @@ def zip_dir(path):
     return temp_zip
 
 
-def upload_project(path, endpoint):
+def upload_project(path, endpoint, save=None):
     filename = os.path.basename(path)
     if str(path).endswith(('.zip', '.yaml', '.yml')):
         file = open(path, "b+r")
     else:
         filename += '.zip'
         file = zip_dir(path)
+        if save is not None and save.endswith(".zip") and not os.path.exists(save):
+            copyfile(file.name, save)
+
     display_project(rest_crud.post_binary_files_storage(endpoint, file, filename))
 
 

--- a/tests/commands/project/test_upload.py
+++ b/tests/commands/project/test_upload.py
@@ -44,19 +44,13 @@ class TestUpload:
         basename = file.name
 
         try: # negative test case
-            neoLoad_project.save_local(source_path, basename+".bad")
+            neoLoad_project.zip_dir(source_path,basename+".bad")
             assert False, "Bad extension should have been rejected, but wasn't"
         except:
             assert True
 
-        try: # negative test case; zip shouldn't exist before save (but does)
-            neoLoad_project.save_local(source_path, basename)
-            assert False, "Doesn't catch an overwrite scenario"
-        except:
-            assert True
-
         os.remove(basename)
-        neoLoad_project.save_local(source_path, basename)
+        neoLoad_project.zip_dir(source_path,basename)
         exists = os.path.exists(basename)
         os.remove(basename) # pre-emptive cleanup
 


### PR DESCRIPTION
## What?
A way to save the compressed zip of the upload with .nlignore rules applied. Per customer request.

## Why?
Because .nlignore is not yet respected in NLG export to NLW option, and some teams store other YAMLs (like Azure DevOps pipelines) in their NL test directory and want a way to get at the zip file for manual upload.

## How?
Copy the temp zip file to the path user has specified as part of neoLoad_project.upload_project, provided the path ends in .zip and does not exist (prevent overwrites).

## Testing
New unit test tests/commands/project/test_upload.py::TestUpload::test_upload_with_save added because direct CLI argument usage mocks out the upload process.

## Additional Notes
For prospect/customer OEConnection.