### PR TITLE
Compute version in tools.py to make it available to other commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Pipfile.lock
 .coverage
 coverage.xml
 htmlcov/
+build/
+dist/

--- a/neoload/__main__.py
+++ b/neoload/__main__.py
@@ -6,7 +6,6 @@ import click
 import coloredlogs
 
 from neoload_cli_lib import tools, rest_crud, cli_exception
-from version import __version__
 
 import urllib3
 
@@ -16,15 +15,6 @@ plugin_folder = os.path.join(os.path.dirname(__file__), 'commands')
 
 # Disable output buffering.
 sys.stdout = sys.__stdout__
-
-
-def compute_version():
-    if __version__ is not None:
-        return __version__
-    try:
-        return os.popen('git describe --tags --dirty').read().strip()
-    except (TypeError, ValueError):
-        return "dev"
 
 
 class NeoLoadCLI(click.MultiCommand):
@@ -54,7 +44,7 @@ class NeoLoadCLI(click.MultiCommand):
 @click.command(cls=NeoLoadCLI, help='', chain=True)
 @click.option('--debug', default=False, is_flag=True)
 @click.option('--batch', default=False, is_flag=True, help="Don't ask a question or read stdin")
-@click.version_option(compute_version())
+@click.version_option(tools.compute_version())
 def cli(debug, batch):
     if debug:
         logging.basicConfig()

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -9,6 +9,8 @@ from termcolor import cprint
 
 from neoload_cli_lib import rest_crud, user_data, config_global, filtering
 
+from version import __version__
+
 __regex_id = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 __regex_mongodb_id = re.compile('[a-f\\d]{24}', re.IGNORECASE)
 __true_values = ["true", "yes", "y", "1"]
@@ -16,6 +18,15 @@ __false_values = ["false", "no", "n", "0"]
 __nl_interactive_env_var = 'NL_INTERACTIVE'
 
 __batch = False
+
+
+def compute_version():
+    if __version__ is not None:
+        return __version__
+    try:
+        return os.popen('git describe --tags --dirty').read().strip()
+    except (TypeError, ValueError):
+        return "dev"
 
 
 def __is_color_terminal():


### PR DESCRIPTION
## What?
Move the function to compute the CLI version in tools.py

## Why?
To make the version available to other commands

## Testing
Make a dev release after this is merged on master to be sure that the release process still works
