### PR TITLE
Improve unit testing - createorpatch command

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,6 @@ name: Python package
 on:
   push:
     branches: [ '**' ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:
@@ -31,7 +29,9 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test with pytest
       run: |
-        PYTHONPATH="neoload" coverage3 run -m pytest
+        PYTHONPATH="neoload" COVERAGE_FILE=.coverage.unit coverage3 run -m pytest
+        PYTHONPATH="neoload" COVERAGE_FILE=.coverage.live coverage3 run -m pytest -v -x -m "makelivecalls" --makelivecalls --token ${{ secrets.NLWEB_TOKEN }} --url ${{ secrets.NLWEB_API_URL }} --workspace CLI
+        coverage3 combine
         coverage3 xml
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ markers =
     validation: marks tests of the validation of project yaml format
     acceptance: marks tests of commands in the readme.md
     workspaces: marks tests of the "workspaces" sub-commands
+    makelivecalls: marks test as using live calls to real API (not monkeypatch)

--- a/tests/commands/test_settings/test_createorpatch.py
+++ b/tests/commands/test_settings/test_createorpatch.py
@@ -1,0 +1,66 @@
+import time
+
+import pytest
+from click.testing import CliRunner
+from commands.test_settings import cli as settings
+from commands.status import cli as status
+from commands.logout import cli as logout
+from helpers.test_utils import *
+
+
+@pytest.mark.makelivecalls
+@pytest.mark.settings
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestCreateOrPatch:
+    def test_minimal(self):
+        runner = CliRunner()
+        runner.invoke(settings, ['delete', 'test_name'])
+        runner.invoke(settings, ['use', 'None'])
+        result_status = runner.invoke(status)
+        assert 'settings id:' not in result_status.output
+
+        result = runner.invoke(settings, ['createorpatch', 'test_name'])
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert json_result['name'] == 'test_name'
+        assert json_result['controllerZoneId'] == 'defaultzone'
+        assert json_result['lgZoneIds'] == {'defaultzone': 1}
+        assert json_result['nextRunId'] == 1
+
+        result_status = runner.invoke(status)
+        assert 'settings id: %s' % json_result['id'] in result_status.output
+
+    def test_all_options(self):
+        runner = CliRunner()
+        result = runner.invoke(settings,
+                               ['createorpatch', 'test_name', '--description', 'test description ',
+                                '--scenario', 'scenario name', '--zone', 'defaultzone',
+                                '--lgs', 'defaultzone:5,UdFyn:1', '--naming-pattern', 'test_${runID}'])
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert json_result['name'] == 'test_name'
+        assert json_result['description'] == 'test description '
+        assert json_result['scenarioName'] == 'scenario name'
+        assert json_result['controllerZoneId'] == 'defaultzone'
+        assert json_result['lgZoneIds']['defaultzone'] == 5
+        assert json_result['lgZoneIds']['UdFyn'] == 1
+        assert json_result['testResultNamingPattern'] == 'test_${runID}'
+
+    def test_error_invalid_json(self, valid_data):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with open('bad.json', 'w') as f:
+                f.write('{"key": not valid,,,}')
+            result = runner.invoke(settings, ['createorpatch', '--file', 'bad.json', valid_data.test_settings_id])
+            assert result.exit_code == 1
+            assert 'Error: Expecting value: line 1 column 9 (char 8)' in result.output
+            assert 'This command requires a valid Json input' in result.output
+
+    def test_error_not_logged_in(self):
+        runner = CliRunner()
+        result_logout = runner.invoke(logout)
+        assert_success(result_logout)
+
+        result = runner.invoke(settings, ['createorpatch', 'any'])
+        assert result.exit_code == 1
+        assert 'You aren\'t logged' in str(result.output)


### PR DESCRIPTION
## What?
Add ability to make live calls on a real NLW in a specific workspace for unit tests marked as "makelivecalls"
The coverage is computed on both tests live calls and regular unit tests.

## Why?
To easily test the report command on a real test. This will avoid making complicated mocks.

## How?
Mark the tests with "@pytest.mark.makelivecalls"

## Additional notes
The trigger of Github actions on  "PR" is removed to avoid duplicate builds (on push an on PR)