### PR TITLE
Fix user agent header value when chaining commands

### DIFF
--- a/neoload/__main__.py
+++ b/neoload/__main__.py
@@ -31,7 +31,6 @@ class NeoLoadCLI(click.MultiCommand):
         """Dynamically get the command."""
         ns = {}
         fn = os.path.join(plugin_folder, name.replace('-', '_') + '.py')
-        rest_crud.set_current_command(name)
         if os.path.isfile(fn):
             with open(fn) as f:
                 code = compile(f.read(), fn, 'exec')

--- a/neoload/commands/config.py
+++ b/neoload/commands/config.py
@@ -2,7 +2,7 @@ import ast
 
 import click
 
-from neoload_cli_lib import config_global
+from neoload_cli_lib import config_global, rest_crud
 
 
 @click.command()
@@ -10,6 +10,7 @@ from neoload_cli_lib import config_global
 @click.argument('key_value', nargs=-1, required=False)
 def cli(command, key_value):
     """View and set the user-defined properties. This properties is kept after logout. The format of KEY_VALUE: key1=value1 key2=value2. The empty value remove the key"""
+    rest_crud.set_current_command()
     if command == 'set':
         for element in key_value:
             key, value = element.split('=')

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -1,7 +1,7 @@
 import click
 
 from commands import test_results
-from neoload_cli_lib import displayer, running_tools, tools
+from neoload_cli_lib import displayer, running_tools, tools, rest_crud
 from datetime import datetime, date
 import time
 import sys
@@ -14,6 +14,7 @@ import sys
 @click.option("--max-failure", 'max_failure', type=int, default=0, help="Max SLA failure threshold; default is zero")
 def cli(command, name, stop, force, max_failure): #, max_occurs):
     """Fails if certain conditions are met, such as per-run SLAs failed % of time"""
+    rest_crud.set_current_command()
     if not command:
         tools.system_exit({'message': "command is mandatory. Please see neoload fastfail --help", 'code': 2})
         return

--- a/neoload/commands/login.py
+++ b/neoload/commands/login.py
@@ -2,7 +2,7 @@ import sys
 import click
 
 from commands import workspaces
-from neoload_cli_lib import user_data, tools
+from neoload_cli_lib import user_data, tools, rest_crud
 
 
 @click.command()
@@ -14,6 +14,7 @@ from neoload_cli_lib import user_data, tools
 def cli(token, url, no_write, workspace, ssl_cert):
     """Store your token and API url of NeoLoad Web. The token is read from stdin if none is set.
     The default API url is "https://neoload-api.saas.neotys.com/" """
+    rest_crud.set_current_command()
     if not token:
         if sys.stdin.isatty():
             token = click.prompt("Enter your token", None, True)

--- a/neoload/commands/project.py
+++ b/neoload/commands/project.py
@@ -12,6 +12,7 @@ import os
 @click.argument("name_or_id", type=str, required=False)
 def cli(command, name_or_id, path, save):
     """Upload and list scenario from settings"""
+    rest_crud.set_current_command()
     if not name_or_id or name_or_id == "cur":
         name_or_id = user_data.get_meta(test_settings.meta_key)
 

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -21,6 +21,7 @@ from neoload_cli_lib import running_tools, tools, rest_crud, user_data
               help="return 0 when test is correctly launched, whatever the result of SLA")
 def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_vu, citrix_vu, return_0):
     """run a test"""
+    rest_crud.set_current_command()
     if not name_or_id or name_or_id == "cur":
         name_or_id = user_data.get_meta(test_settings.meta_key)
 

--- a/neoload/commands/stop.py
+++ b/neoload/commands/stop.py
@@ -1,7 +1,7 @@
 import click
 
 from commands import test_results
-from neoload_cli_lib import tools, user_data, running_tools, cli_exception
+from neoload_cli_lib import tools, user_data, running_tools, cli_exception, rest_crud
 
 
 @click.command()
@@ -9,6 +9,7 @@ from neoload_cli_lib import tools, user_data, running_tools, cli_exception
 @click.argument('name', required=False)
 def cli(name, force):
     """stop a test"""
+    rest_crud.set_current_command()
     if not name or name == "cur":
         name = user_data.get_meta(test_results.meta_key)
     if not name:

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -44,6 +44,7 @@ def cli(command, name, rename, description, quality_status, junit_file, file, fi
     use      # Remember the test result you want to work on. Example : neoload
     |          test-results use MyTest#1 ; neoload test-results summary      .
     """
+    rest_crud.set_current_command()
     if not command:
         print("command is mandatory. Please see neoload tests-results --help")
         return

--- a/neoload/commands/test_settings.py
+++ b/neoload/commands/test_settings.py
@@ -39,6 +39,7 @@ def cli(command, name, rename, description, scenario, controller_zone_id, lg_zon
     |        test-settings use MyTest ; neoload test-settings delete         .
     createorpatch # Create a new test or patch an existing one; useful in CI .
     """
+    rest_crud.set_current_command()
     if not command:
         print("command is mandatory. Please see neoload tests-settings --help")
         return

--- a/neoload/commands/wait.py
+++ b/neoload/commands/wait.py
@@ -1,7 +1,7 @@
 import click
 
 from commands import test_results
-from neoload_cli_lib import running_tools, user_data, tools
+from neoload_cli_lib import running_tools, user_data, tools, rest_crud
 
 
 @click.command()
@@ -10,6 +10,7 @@ from neoload_cli_lib import running_tools, user_data, tools
               help="return 0 when test is correctly launched, whatever the result of SLA")
 def cli(name_or_id, return_0):
     """Wait the end of test"""
+    rest_crud.set_current_command()
     if not name_or_id or name_or_id == "cur":
         name_or_id = user_data.get_meta(test_results.meta_key)
 

--- a/neoload/commands/workspaces.py
+++ b/neoload/commands/workspaces.py
@@ -16,6 +16,7 @@ def cli(command, name_or_id):
     ls     # Lists workspaces                                                .
     use    # Remember the workspace you want to work on                      .
     """
+    rest_crud.set_current_command()
     if not command:
         print("command is mandatory. Please see neoload workspaces --help")
         return

--- a/neoload/commands/zones.py
+++ b/neoload/commands/zones.py
@@ -8,6 +8,7 @@ from neoload_cli_lib import rest_crud, tools
 @click.option("--static/--dynamic", "static_dynamic", default=None, help="filter for dynamic or static zones")
 def cli(name_or_id, static_dynamic, human):
     """read of NeoLoad Web zones"""
+    rest_crud.set_current_command()
     resp = rest_crud.get(get_end_point())
     resp = [elem for elem in resp if filter_result(elem, name_or_id, static_dynamic)]
     if human:


### PR DESCRIPTION
## What?

- Fix issue : while chaining neoload commands, the command in the user-agent was always the last command of the chain.
- Only send a  header user-agent in one request per CLI command. We don't want to send a user-agent for example for all "GET test-results" requests while running a test.

## Why?
To have more accurate info on how the CLI is used

## How?
Issue : Before the "rest_crud.set_command()" was called in the main.py, but all commands are loaded at the beginning. That's why we need to call "set_command" into each "cli()" function.
