### PR TITLE
Add custom command support to fastfail

### DIFF
--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -5,6 +5,7 @@ from neoload_cli_lib import displayer, running_tools, tools
 from datetime import datetime, date
 import time
 import sys
+import os
 
 @click.command()
 @click.argument('command', type=click.Choice(['slas'], case_sensitive=False))
@@ -12,7 +13,8 @@ import sys
 @click.option("--stop", 'stop', is_flag=True, default=True, help="Doesn't wait the end of test")
 @click.option("--force", 'force', is_flag=True, default=True, help="Doesn't wait the end of test")
 @click.option("--max-failure", 'max_failure', type=int, default=0, help="Max SLA failure threshold; default is zero")
-def cli(command, name, stop, force, max_failure): #, max_occurs):
+@click.option("--command", "-c", 'custom_command', required=False, help="Custom system command to execute when fastfail is triggered")
+def cli(command, name, stop, force, max_failure, custom_command): #, max_occurs):
     """Fails if certain conditions are met, such as per-run SLAs failed % of time"""
     if not command:
         tools.system_exit({'message': "command is mandatory. Please see neoload fastfail --help", 'code': 2})
@@ -29,12 +31,12 @@ def cli(command, name, stop, force, max_failure): #, max_occurs):
         return
 
     if command == "slas":
-        monitor_loop(__id, stop, force, max_failure)
+        monitor_loop(__id, stop, force, max_failure, custom_command)
 
     else:
         tools.system_exit({'message': "Invalid command. Please see neoload fastfail --help", 'code': 2})
 
-def monitor_loop(__id, stop, force, max_failure):
+def monitor_loop(__id, stop, force, max_failure, custom_command):
     dt_started = datetime.now()
     print('fastfail started: ' + str(dt_started))
     dt_current = dt_started
@@ -65,7 +67,13 @@ def monitor_loop(__id, stop, force, max_failure):
         if len(partial_intervals) > 0 and len(failed_intervals) < 1:
             msg += "\nSome SLAs failed, but were not above max-failure of {0}% so did not count as error.".format(max_failure)
 
-        outcomes = process_state(datas,fails,stop,force,is_initializing,is_running,msg)
+        fail_options = {
+            'stop': stop,
+            'force': force,
+            'custom_command': custom_command
+        }
+
+        outcomes = process_state(datas,fails,fail_options,is_initializing,is_running,msg)
 
         final_run = has_exited and outcomes["has_exited"]
         has_exited = outcomes["has_exited"]
@@ -91,7 +99,12 @@ def monitor_loop(__id, stop, force, max_failure):
 
     tools.system_exit({'message': msg, 'code': exit_code})
 
-def process_state(datas,fails,stop,force,is_initializing,is_running,msg):
+def process_state(datas,fails,fail_options,is_initializing,is_running,msg):
+
+    stop = fail_options['stop']
+    force = fail_options['force']
+    custom_command = fail_options['custom_command']
+
     ret = {
         "has_exited": False,
         "is_initializing": is_initializing,
@@ -101,6 +114,10 @@ def process_state(datas,fails,stop,force,is_initializing,is_running,msg):
 
     if len(fails) > 0:
         if status != 'TERMINATED' and stop:
+            if custom_command is not None:
+                print("\nStopping test, custom command={0}".format(custom_command))
+                os.system(custom_command)
+            else:
                 print("\nStopping test, force={0}".format(force))
                 tools.set_batch(True)
                 running_tools.stop(datas["id"], force)

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -5,16 +5,20 @@ from neoload_cli_lib import displayer, running_tools, tools
 from datetime import datetime, date
 import time
 import sys
-import os
+import subprocess
 
 @click.command()
 @click.argument('command', type=click.Choice(['slas'], case_sensitive=False))
 @click.argument("name", type=str, required=False)
-@click.option("--stop", 'stop', is_flag=True, default=True, help="Doesn't wait the end of test")
-@click.option("--force", 'force', is_flag=True, default=True, help="Doesn't wait the end of test")
-@click.option("--max-failure", 'max_failure', type=int, default=0, help="Max SLA failure threshold; default is zero")
-@click.option("--command", "-c", 'custom_command', required=False, help="Custom system command to execute when fastfail is triggered")
-def cli(command, name, stop, force, max_failure, custom_command): #, max_occurs):
+@click.option("--stop", 'stop', is_flag=True, default=True,
+              help="Stop the running test if slas threshold is reached. default is True")
+@click.option("--force", 'force', is_flag=True, default=True,
+              help="Immediately kill Load Generators and do not apply the stop policy. Some statistics may be wrong. default is True")
+@click.option("--max-failure", 'max_failure', type=int, default=0,
+              help="Max SLA percentage failure threshold; default is zero")
+@click.option("--stop-command", 'stop_command', required=False,
+              help="System command that will be executed instead of stopping NLW test. Optional.")
+def cli(command, name, stop, force, max_failure, stop_command): #, max_occurs):
     """Fails if certain conditions are met, such as per-run SLAs failed % of time"""
     if not command:
         tools.system_exit({'message': "command is mandatory. Please see neoload fastfail --help", 'code': 2})
@@ -31,12 +35,12 @@ def cli(command, name, stop, force, max_failure, custom_command): #, max_occurs)
         return
 
     if command == "slas":
-        monitor_loop(__id, stop, force, max_failure, custom_command)
+        monitor_loop(__id, stop, force, max_failure, stop_command)
 
     else:
         tools.system_exit({'message': "Invalid command. Please see neoload fastfail --help", 'code': 2})
 
-def monitor_loop(__id, stop, force, max_failure, custom_command):
+def monitor_loop(__id, stop, force, max_failure, stop_command):
     dt_started = datetime.now()
     print('fastfail started: ' + str(dt_started))
     dt_current = dt_started
@@ -70,10 +74,10 @@ def monitor_loop(__id, stop, force, max_failure, custom_command):
         fail_options = {
             'stop': stop,
             'force': force,
-            'custom_command': custom_command
+            'stop_command': stop_command
         }
 
-        outcomes = process_state(datas,fails,fail_options,is_initializing,is_running,msg)
+        outcomes = process_state(datas,fails,fail_options,is_initializing,is_running)
 
         final_run = has_exited and outcomes["has_exited"]
         has_exited = outcomes["has_exited"]
@@ -99,11 +103,11 @@ def monitor_loop(__id, stop, force, max_failure, custom_command):
 
     tools.system_exit({'message': msg, 'code': exit_code})
 
-def process_state(datas,fails,fail_options,is_initializing,is_running,msg):
+def process_state(datas,fails,fail_options,is_initializing,is_running):
 
     stop = fail_options['stop']
     force = fail_options['force']
-    custom_command = fail_options['custom_command']
+    stop_command = fail_options['stop_command']
 
     ret = {
         "has_exited": False,
@@ -114,9 +118,10 @@ def process_state(datas,fails,fail_options,is_initializing,is_running,msg):
 
     if len(fails) > 0:
         if status != 'TERMINATED' and stop:
-            if custom_command is not None:
-                print("\nStopping test, custom command={0}".format(custom_command))
-                os.system(custom_command)
+            if stop_command is not None:
+                out = subprocess.run(stop_command, shell=True, capture_output=True)
+                print(f"\nStopping test with the system command {out.args}\n - return code={out.returncode}")
+                print(f" - stdout={out.stdout}\n - stderr={out.stderr}")
             else:
                 print("\nStopping test, force={0}".format(force))
                 tools.set_batch(True)


### PR DESCRIPTION
## What?
Ability to specify an arbitrary (direct REST API to controller) command to stop the test, instead of issuing the command to the NLW REST APIs.

## Why?
Customer using NeoLoadCmd with cloud load generators but streaming to NLW needs fastfail to monitor SLA data as usual, but trigger a localhost REST API call into the NeoLoadCmd build container to stop the test, since it is not a test-settings based execution from NLW.

## How?
Provide a -c parameter to allow user to make whatever system call (execute a curl command or teardown procedure) of their choosing when fastfail conditions are met.

## Testing
Using personal AWS CodeBuild process already setup to demo for WFM/Amazon ProServe: https://github.com/paulsbruce/neoload-ci-utility/blob/master/pipelines/aws/CustomController/buildspec_ncp.yaml

## Additional Notes
Until we have NCP integrated as a zone in NLW, this is what customer needs, now, while project resources are working on their solution. Fastfail is a minimum-viable functionality for modern pipelines from their perspective.
