### PR TITLE
Add Docker command

### DIFF
--- a/neoload/__main__.py
+++ b/neoload/__main__.py
@@ -6,6 +6,7 @@ import click
 import coloredlogs
 
 from neoload_cli_lib import tools, rest_crud, cli_exception
+from neoload_cli_lib.cli_exception import CliException
 
 import urllib3
 
@@ -61,4 +62,12 @@ def cli(debug, batch):
 
 
 if __name__ == '__main__':
-    cli()
+    try:
+        cli()
+    except CliException as ex:
+        print(ex.format_message(), file = sys.stderr)
+    except Exception as ex:
+        if cli_exception.CliException.is_debug():
+            raise ex
+        else:
+            print(ex.__str__(), file=sys.stderr)

--- a/neoload/commands/docker.py
+++ b/neoload/commands/docker.py
@@ -1,0 +1,46 @@
+import click
+
+from neoload_cli_lib import docker_lib, rest_crud
+
+
+@click.command()
+@click.argument('command', required=True,
+                type=click.Choice(['up', 'down', 'clean', 'forget', 'install', 'uninstall', 'status']))
+@click.option('--no-wait', is_flag=True,
+              help="Do not wait for controller and load generator in zones api", default=False)
+def cli(command, no_wait):
+    """\b
+    Use local Docker to BYO infrastructure for a test.
+    This uses the local Docker daemon to spin up containers to be used as infrastucture for the current test.
+    Commands:
+        - up/down: create or delete container depends of the configuration
+        - forget: remove container from the launched list. That avoid to be removed with down command.
+        - clean: remove all container created by neoload-cli even if it was forgotten.
+        - install/uninstall: add/remove hooks on run command to up when the controller zone is same and zone is empty. Shut down at the end of test running.
+        - status: display configuration and general status.
+
+    \b
+    configuration are :
+        - docker.controller.image (default:  neotys/neoload-controller:latest)
+        - docker.controller.default_count (default: 1)
+        - docker.lg.image (default: neotys/neoload-loadgenerator:latest)
+        - docker.lg.default_count (default: 2)
+        - docker.zone
+
+    \b
+    NOTE: this feature is not supported by NeoLoad since your own Docker configuration is out-of-scope for support."""
+    rest_crud.set_current_command()
+    if command == "install":
+        docker_lib.install()
+    elif command == "uninstall":
+        docker_lib.uninstall()
+    elif command == "status":
+        docker_lib.status()
+    elif command == "up":
+        docker_lib.up(no_wait)
+    elif command == "down":
+        docker_lib.down()
+    elif command == "clean":
+        docker_lib.clean()
+    elif command == "forget":
+        docker_lib.forget()

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -4,7 +4,7 @@ from urllib.parse import quote
 import click
 
 from commands import test_settings, test_results
-from neoload_cli_lib import running_tools, tools, rest_crud, user_data
+from neoload_cli_lib import running_tools, tools, rest_crud, user_data, hooks
 
 
 @click.command()
@@ -36,6 +36,8 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
     if not naming_pattern:
         naming_pattern = "#${runID}"
     naming_pattern = naming_pattern.replace('${runID}', str(test_settings_json['nextRunId']))
+
+    hooks.trig("test.start", test_settings_json)
 
     # Sorry for that, post data are in the query string :'( :'(
     post_result = rest_crud.post(

--- a/neoload/commands/zones.py
+++ b/neoload/commands/zones.py
@@ -9,12 +9,16 @@ from neoload_cli_lib import rest_crud, tools
 def cli(name_or_id, static_dynamic, human):
     """read of NeoLoad Web zones"""
     rest_crud.set_current_command()
-    resp = rest_crud.get(get_end_point())
+    resp = get_zones()
     resp = [elem for elem in resp if filter_result(elem, name_or_id, static_dynamic)]
     if human:
         print_human(resp)
     else:
         tools.print_json(resp)
+
+
+def get_zones():
+    return rest_crud.get(get_end_point())
 
 
 def get_end_point(id_zone: str = None):

--- a/neoload/neoload_cli_lib/__init__.py
+++ b/neoload/neoload_cli_lib/__init__.py
@@ -1,2 +1,2 @@
 __all__ = ["user_data", "rest_crud", "running_tools", "cli_exception", "displayer", "schema_validation",
-           "name_resolver", "neoLoad_project", "tools"]
+           "name_resolver", "neoLoad_project", "tools", "docker_lib"]

--- a/neoload/neoload_cli_lib/cli_exception.py
+++ b/neoload/neoload_cli_lib/cli_exception.py
@@ -20,3 +20,7 @@ class CliException(click.ClickException):
         if CliException.__debug:
             __message = traceback.format_exc() + "\n\n" + __message
         return __message
+
+    @staticmethod
+    def is_debug():
+        return CliException.__debug

--- a/neoload/neoload_cli_lib/config_global.py
+++ b/neoload/neoload_cli_lib/config_global.py
@@ -45,3 +45,9 @@ def __load():
 
 
 __config_global = __load()
+
+
+def reset():
+    global __config_global
+    __config_global = {}
+    _save()

--- a/neoload/neoload_cli_lib/docker_lib.py
+++ b/neoload/neoload_cli_lib/docker_lib.py
@@ -1,0 +1,329 @@
+from neoload_cli_lib import user_data, tools, hooks, config_global, cli_exception
+from commands import zones
+import sys
+import docker
+import traceback
+import logging
+import re
+import socket
+import time
+
+DOCKER_LAUNCHED = 'docker.launched'
+DOCKER_ZONE = 'docker.zone'
+DOCKER_LG_DEFAULT_COUNT = 'docker.lg.default_count'
+DOCKER_LG_IMAGE = 'docker.lg.image'
+DOCKER_CONTROLLER_DEFAULT_COUNT = 'docker.controller.default_count'
+DOCKER_CONTROLLER_IMAGE = 'docker.controller.image'
+
+default_settings = {
+    DOCKER_CONTROLLER_IMAGE: 'neotys/neoload-controller:latest',
+    DOCKER_CONTROLLER_DEFAULT_COUNT: 1,
+    DOCKER_LG_IMAGE: 'neotys/neoload-loadgenerator:latest',
+    DOCKER_LG_DEFAULT_COUNT: 2,
+    DOCKER_ZONE: 'defaultzone',
+    DOCKER_LAUNCHED: []
+}
+
+client = docker.from_env()
+
+
+def get_setting(key):
+    return config_global.get_attr(key, default_settings.get(key))
+
+
+def add_set(key, list_to_add):
+    old_list = get_setting(key)
+    config_global.set_attr(key, old_list + list_to_add)
+
+
+def install():
+    hooks.register("test.start", "neoload_cli_lib.docker_lib.hook_test_start")
+    hooks.register("test.stop", "neoload_cli_lib.docker_lib.hook_test_stop")
+
+
+def uninstall():
+    hooks.unregister("test.start", "neoload_cli_lib.docker_lib.hook_test_start")
+    hooks.unregister("test.stop", "neoload_cli_lib.docker_lib.hook_test_stop")
+
+
+def status():
+    installed = "installed" if hooks.is_registered("test.start",
+                                                   "neoload_cli_lib.docker_lib.hook_test_start") else "not installed"
+    print("configuration:")
+
+    for k in default_settings:
+        print(k + " = " + str(get_setting(k)))
+
+    print()
+    print("docker hooks is " + installed)
+    print()
+    check_images(DOCKER_LG_IMAGE)
+    check_images(DOCKER_CONTROLLER_IMAGE)
+
+    check_docker()
+
+    launched_container = get_setting(DOCKER_LAUNCHED)
+    if launched_container:
+        print("\ncontainers :")
+        for c_id in launched_container:
+            print(container_status(c_id))
+    else:
+        try:
+            check_zone(get_setting(DOCKER_ZONE))
+        except cli_exception.CliException as ex:
+            print(str(ex))
+
+
+def container_status(container_id):
+    try:
+        container = client.containers.get(container_id)
+        return container.name + ' [' + container.status + ']'
+    except docker.errors.NotFound:
+        return container_id + ' [NOT FOUND]'
+
+
+def check_images(key):
+    image_name = get_setting(key)
+    image_status = " is not pulled" if len(client.images.list(image_name)) == 0 else " is pulled"
+    print("image " + image_name + image_status)
+
+
+def up(no_wait):
+    zone = get_setting(DOCKER_ZONE)
+    check_zone(zone)
+    start_infra(
+        zone,
+        int(get_setting(DOCKER_CONTROLLER_DEFAULT_COUNT)),
+        int(get_setting(DOCKER_LG_DEFAULT_COUNT)),
+        no_wait,
+        'manual'
+    )
+
+
+def check_zone(zone_set):
+    zone = get_zone(zone_set)
+    if not zone:
+        raise cli_exception.CliException("zone " + zone_set + " doesn't exist")
+    if zone.get('type') != "STATIC":
+        raise cli_exception.CliException("zone " + zone_set + " is not static !")
+    if zone.get('controller'):
+        raise cli_exception.CliException(
+            "controller with " + zone_set + " zone is not empty. Try neoload docker clean")
+    if zone.get('loadgenerators'):
+        logging.warning("lg zone with " + zone_set + " is not empty. Try neoload docker clean")
+
+
+def get_zone(zone_id):
+    for zone in zones.get_zones():
+        if zone.get('id') == zone_id:
+            return zone
+    return None
+
+
+def down():
+    stop_infra()
+
+
+def compute_hosts(lg_containers):
+    hosts = {}
+    for lg_container in lg_containers:
+        lg_container.reload()  # refresh data after launch.
+        hosts[lg_container.name] = lg_container.attrs['NetworkSettings']['IPAddress']
+    return hosts
+
+
+def generate_conf_ctrl(zone, lg_containers):
+    env = {"MODE": "Managed"}
+    env.update(common_env(zone))
+    return {
+        'env': env,
+        'name_prefix': 'ctrl',
+        'hosts': compute_hosts(lg_containers)
+    }
+
+
+def generate_conf_lg(zone):
+    return {
+        'env': common_env(zone),
+        'name_prefix': 'lg'
+    }
+
+
+def stop_infra():
+    for container_id in get_setting(DOCKER_LAUNCHED):
+        try:
+            container = client.containers.get(container_id)
+            container.stop()
+        except docker.errors.NotFound:
+            pass
+    forget()
+
+
+def common_env(zone):
+    return {
+        "NEOLOADWEB_URL": user_data.get_user_data().get_url(),
+        "NEOLOADWEB_TOKEN": user_data.get_user_data().get_token(),
+        "ZONE": zone
+    }
+
+
+def launch_ctrl(count, zone, lg_containers, reason):
+    image = pull_if_needed(get_setting(DOCKER_CONTROLLER_IMAGE))
+    return start_container(image, generate_conf_ctrl(zone, lg_containers), count, reason)
+
+
+def launch_lg(count, zone, reason):
+    image = pull_if_needed(get_setting(DOCKER_LG_IMAGE))
+    return start_container(image, generate_conf_lg(zone), count, reason)
+
+
+def extract_number(prefix, element):
+    num, number_match = re.subn("^" + prefix + "-([0-9]+)-.*$", r"\g<1>", element.name)
+    return int(num) if number_match > 0 else 0
+
+
+def max_number(prefix):
+    containers_list = client.containers.list(all=True)
+    return max(map(lambda c: extract_number(prefix, c), containers_list))
+
+
+def start_container(image, configuration, count, reason):
+    prefix = configuration.get('name_prefix')
+    number = max_number(prefix)
+    containers = []
+    for i in range(count):
+        name = prefix + '-' + str(number + i + 1) + '-' + socket.gethostname().lower()
+        container = client.containers.run(
+            image=image.id,
+            name=name,
+            hostname=name,
+            labels={'launched-by-neoload-cli': reason},
+            detach=True,
+            extra_hosts=configuration.get('hosts', {}),
+            auto_remove=True,
+            environment=configuration.get('env', {})
+        )
+        containers.append(container)
+    return containers
+
+
+def make_waiting(containers_name, zone):
+    waiting_list = []
+    names = list(map(lambda c: c['name'], zone.get('controllers') + zone.get('loadgenerators')))
+    for c_name in containers_name:
+        if c_name not in names:
+            waiting_list.append(c_name)
+    return waiting_list
+
+
+def wait_is_up(containers, zone_id):
+    containers_name = map(lambda c: c.name, containers)
+    while True:
+        time.sleep(5)
+        waiting = make_waiting(containers_name, get_zone(zone_id))
+        if waiting:
+            print("Waiting: " + str(waiting))
+        else:
+            break
+
+
+def start_infra(zone_id, ctrl_count: int, lg_count: int, no_wait, reason):
+    containers = []
+    try:
+        containers = launch_lg(lg_count, zone_id, reason)
+        containers += launch_ctrl(ctrl_count, zone_id, containers, reason)
+        add_set(DOCKER_LAUNCHED, list(map(lambda c: c.id, containers)))
+        if not no_wait:
+            wait_is_up(containers, zone_id)
+    except docker.errors.DockerException as ex:
+        for container in containers:
+            container.stop()
+        logging.error("Unexpected error in 'attach':" + str(ex))
+
+
+def extract_lg_number(test_settings_json, zone):
+    number_lg = test_settings_json.get('lgZoneIds').get(zone)
+    return number_lg if number_lg else 0
+
+
+def hook_test_start(test_settings_json):
+    zone = get_setting(DOCKER_ZONE)
+    if test_settings_json.get('controllerZoneId') == zone:
+        number_lg = extract_lg_number(test_settings_json, zone)
+        zone_obj = get_zone(zone)
+        if number_lg <= len(zone_obj.get('loadgenerators')) and 1 <= len(zone_obj.get('controllers')):
+            print("zone is already up", file=sys.stderr)
+            return
+
+        print("Launch docker containers", file=sys.stderr)
+
+        check_zone(zone)
+        start_infra(
+            zone,
+            1,
+            number_lg,
+            False,
+            test_settings_json.get('id')
+        )
+
+
+def hook_test_stop():
+    print("Stop docker containers", file=sys.stderr)
+    stop_infra()
+
+
+def pull_if_needed(image_name):
+    try:
+        return client.images.get(image_name)
+    except docker.errors.ImageNotFound:
+        print("Pulling [" + image_name + "]", file=sys.stderr)
+        return client.images.pull(image_name)
+
+
+def check_docker():
+    preempt_msg = "Unexpected error in 'try_docker_system':"
+    try:
+        preempt_msg = "Could not ping the Docker host."
+        client.ping()
+
+        preempt_msg = "Could not obtain version info from the Docker host."
+        client.version()
+
+        preempt_msg = "Could not list containers on the Docker host."
+        client.containers.list()
+
+    except Exception:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        full_msg = preempt_msg + repr(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        lower = full_msg.lower()
+        if 'connectionerror' in lower and 'permission denied' in lower:
+            msg = preempt_msg + " Do you have rights (i.e. sudo first)?"
+        elif 'connection refused' in lower:
+            msg = "Docker installed, but connection to dockerd failed."
+        else:
+            msg = "Docker-specific error: " + full_msg
+
+        tools.system_exit({'message': msg, 'code': 2})
+
+
+def clean():
+    list_to_clean = client.containers.list(all=True, filters={'label': 'launched-by-neoload-cli'})
+    for container in list_to_clean:
+        container.stop()
+    forget()
+
+
+def kill():
+    list_to_clean = client.containers.list(all=True, filters={'label': 'launched-by-neoload-cli'})
+    for container in list_to_clean:
+        container.remove(force=True, v=True)
+    forget()
+
+
+def forget():
+    config_global.set_attr(DOCKER_LAUNCHED, None)
+
+
+def set_client(new_client):
+    global client
+    client = new_client

--- a/neoload/neoload_cli_lib/docker_lib.py
+++ b/neoload/neoload_cli_lib/docker_lib.py
@@ -15,6 +15,9 @@ DOCKER_LG_IMAGE = 'docker.lg.image'
 DOCKER_CONTROLLER_DEFAULT_COUNT = 'docker.controller.default_count'
 DOCKER_CONTROLLER_IMAGE = 'docker.controller.image'
 
+HOOK_TEST_START = "neoload_cli_lib.docker_lib.hook_test_start"
+HOOK_TEST_STOP = "neoload_cli_lib.docker_lib.hook_test_stop"
+
 default_settings = {
     DOCKER_CONTROLLER_IMAGE: 'neotys/neoload-controller:latest',
     DOCKER_CONTROLLER_DEFAULT_COUNT: 1,
@@ -37,18 +40,18 @@ def add_set(key, list_to_add):
 
 
 def install():
-    hooks.register("test.start", "neoload_cli_lib.docker_lib.hook_test_start")
-    hooks.register("test.stop", "neoload_cli_lib.docker_lib.hook_test_stop")
+    hooks.register("test.start", HOOK_TEST_START)
+    hooks.register("test.stop", HOOK_TEST_STOP)
 
 
 def uninstall():
-    hooks.unregister("test.start", "neoload_cli_lib.docker_lib.hook_test_start")
-    hooks.unregister("test.stop", "neoload_cli_lib.docker_lib.hook_test_stop")
+    hooks.unregister("test.start", HOOK_TEST_START)
+    hooks.unregister("test.stop", HOOK_TEST_STOP)
 
 
 def status():
     installed = "installed" if hooks.is_registered("test.start",
-                                                   "neoload_cli_lib.docker_lib.hook_test_start") else "not installed"
+                                                   HOOK_TEST_START) else "not installed"
     print("configuration:")
 
     for k in default_settings:

--- a/neoload/neoload_cli_lib/hooks.py
+++ b/neoload/neoload_cli_lib/hooks.py
@@ -1,0 +1,37 @@
+from neoload_cli_lib import config_global
+
+__prefix = "$hooks"
+
+
+def trig(name, *args, **kwargs):
+    functions_to_trig = config_global.get_attr(__prefix + "." + name)
+    if functions_to_trig:
+        for function_to_trig in functions_to_trig:
+            split = function_to_trig.split('.')
+            module = __import__(split[0])
+            for comp in split[1:]:
+                module = getattr(module, comp)
+            module(*args, **kwargs)
+
+
+def register(name, function):
+    hook = config_global.get_attr(__prefix + "." + name)
+    hook_set = set(hook) if hook else set()
+
+    hook_set.add(function)
+    config_global.set_attr(__prefix + "." + name, list(hook_set))
+
+
+def unregister(name, function):
+    hook = config_global.get_attr("$hooks." + name)
+    if hook:
+        hook.remove(function)
+        if hook:
+            config_global.set_attr("$hooks." + name, list(hook))
+        else:
+            config_global.set_attr(__prefix + "." + name, None)
+
+
+def is_registered(name, function):
+    hook = config_global.get_attr(__prefix + "." + name)
+    return hook and function in hook

--- a/neoload/neoload_cli_lib/running_tools.py
+++ b/neoload/neoload_cli_lib/running_tools.py
@@ -4,7 +4,7 @@ import webbrowser
 from signal import signal, SIGINT
 
 from commands import logs_url, test_results
-from neoload_cli_lib import tools, rest_crud
+from neoload_cli_lib import tools, rest_crud,hooks
 
 __current_id = None
 __count = 0
@@ -29,6 +29,7 @@ def wait(results_id, exit_code_sla):
         time.sleep(20)
 
     __current_id = None
+    hooks.trig("test.stop")
     tools.system_exit(test_results.summary(results_id), exit_code_sla)
 
 
@@ -85,5 +86,6 @@ def stop(results_id, force: bool, quit_option=False):
     policy = 'TERMINATE' if force else 'GRACEFUL'
     if tools.confirm("Do you want stop the test" + results_id + " with " + policy.lower() + " policy ?", quit_option):
         rest_crud.post(test_results.get_end_point(results_id, "/stop"), {"stopPolicy": policy})
+        hooks.trig("test.stop")
         return True
     return False

--- a/tests/neoload_cli_lib/test_docker.py
+++ b/tests/neoload_cli_lib/test_docker.py
@@ -1,0 +1,182 @@
+import tempfile
+import unittest
+from unittest import mock
+
+import docker
+import requests
+from docker.models.containers import ContainerCollection
+
+from neoload_cli_lib import config_global
+from neoload_cli_lib import docker_lib
+from neoload_cli_lib.cli_exception import CliException
+from neoload_cli_lib.user_data import UserData
+
+
+class MockImage:
+    def __init__(self, i):
+        self.name = i
+        self.id = i
+
+
+class MockContainer:
+    count = 0
+
+    def __init__(self, dict):
+        name = dict.get('name')
+        self.name = name
+        self.id = name
+        self.args = dict
+        self.attrs = {}
+
+    def reload(self):
+        MockContainer.count += 1
+        self.attrs = {'NetworkSettings':{'IPAddress': ('172.17.0.'+str(MockContainer.count))}}
+
+
+class MockDocker:
+    def __init__(self):
+        self.containers = {}
+        self.images = {}
+
+
+class LgContainerMock:
+    def reload(self):
+        pass
+
+    def __init__(self, ip):
+        self.attrs = {'NetworkSettings': {'IPAddress': ip}}
+        self.name = ip.replace('.', '_')
+
+
+# Because Mock doesn't support name as native.
+class MockName:
+    def __init__(self, name):
+        self.name = name
+
+
+class TestMethods(unittest.TestCase):
+    """ Class for executing unittest test cases """
+
+    @mock.patch('requests.get', mock.Mock(
+        side_effect=lambda k: {'aurl': 'a response', 'burl': 'b response'}.get(k, 'unhandled request %s' % k)))
+    def test_mock(self):
+        print(requests.get("aurl"))
+
+    @mock.patch('neoload_cli_lib.docker_lib.get_zone', mock.Mock(
+        side_effect=lambda k: {'default_zone': {'type': 'STATIC'}}.get(k, 'unhandled request %s' % k)))
+    def test_get_zone(self):
+        docker_lib.check_zone("default_zone")
+
+    @mock.patch('neoload_cli_lib.docker_lib.get_zone', mock.Mock(
+        side_effect=lambda k: {'default_zone': {'type': 'STATIC', 'controller': 1}}.get(k, 'unhandled request %s' % k)))
+    def test_get_zone_fail_other_controller(self):
+        with self.assertRaises(CliException):
+            docker_lib.check_zone("default_zone")
+
+    @mock.patch('neoload_cli_lib.docker_lib.get_zone', mock.Mock(side_effect=lambda k: {'defaultzone': {'type': 'DYNAMIC'}}.get(k, 'unhandled request %s' % k)))
+    def test_get_zone2(self):
+        with self.assertRaises(CliException):
+            docker_lib.check_zone("defaultzone")
+
+
+
+    @mock.patch('neoload_cli_lib.user_data.get_user_data', mock.Mock(return_value=UserData(desc={'url': "http://MyUrl", 'token': "mytoken"})))
+    def test_generate_conf_lg(self):
+        assert docker_lib.generate_conf_lg("mytest") == {'env': {'NEOLOADWEB_URL': 'http://MyUrl', 'NEOLOADWEB_TOKEN': 'mytoken', 'ZONE': 'mytest'}, 'name_prefix': 'lg'}
+
+    @mock.patch('neoload_cli_lib.user_data.get_user_data', mock.Mock(return_value=UserData(desc={'url': "http://MyUrl", 'token': "mytoken"})))
+    def test_generate_conf_ctrl(self):
+        assert docker_lib.generate_conf_ctrl("mytest", [LgContainerMock('1.2.3.4'), LgContainerMock('3.2.1.4')]) == {'env': {'MODE': 'Managed', 'NEOLOADWEB_URL': 'http://MyUrl', 'NEOLOADWEB_TOKEN': 'mytoken', 'ZONE': 'mytest'}, 'name_prefix': 'ctrl', 'hosts': {'1_2_3_4': '1.2.3.4', '3_2_1_4': '3.2.1.4'}}
+
+
+
+
+    @mock.patch('neoload_cli_lib.config_global.get_config_file', mock.Mock(return_value=tempfile.gettempdir() + "/" + next(tempfile._get_candidate_names())))
+    def test_docker_install_hooks(self):
+        config_global.reset()
+
+        # settings is empty
+        assert None is config_global.get_attr("$hooks.test.start", None)
+        assert None is config_global.get_attr("$hooks.test.stop", None)
+
+        # install Hooks
+        docker_lib.install()
+        assert "neoload_cli_lib.docker_lib.hook_test_start" in config_global.get_attr("$hooks.test.start", [])
+        assert "neoload_cli_lib.docker_lib.hook_test_stop" in config_global.get_attr("$hooks.test.stop", [])
+
+        # remove Hooks
+        docker_lib.uninstall()
+        assert "neoload_cli_lib.docker_lib.hook_test_start" not in config_global.get_attr("$hooks.test.start", [])
+        assert "neoload_cli_lib.docker_lib.hook_test_stop" not in config_global.get_attr("$hooks.test.stop", [])
+
+
+
+    @mock.patch('neoload_cli_lib.config_global.get_config_file', mock.Mock(return_value=tempfile.gettempdir() + "/" + next(tempfile._get_candidate_names())))
+    @mock.patch('neoload_cli_lib.user_data.get_user_data', mock.Mock(return_value=UserData(desc={'url': "http://MyUrl", 'token': "mytoken"})))
+    @mock.patch('neoload_cli_lib.docker_lib.get_zone', mock.Mock(side_effect=lambda k: {'defaultzone': {'type': 'STATIC'}}.get(k, 'unhandled request %s' % k)))
+    @mock.patch('neoload_cli_lib.docker_lib.max_number', mock.Mock(return_value=5))
+    @mock.patch('socket.gethostname',mock.Mock(return_value='Test-machine'))
+    def test_docker_up(self):
+        client_mock = mock.MagicMock(spec=docker.DockerClient)
+        docker_lib.set_client(client_mock)
+        config_global.reset()
+        images = mock.MagicMock(spec=docker.models.images.ImageCollection)
+        images.get.side_effect = docker.errors.ImageNotFound("not found")
+        images.pull.side_effect = lambda k: MockImage(k)
+        client_mock.images = images
+        client_mock.containers.run.side_effect = lambda **k: MockContainer(k)
+        docker_lib.up(True)
+        calls = [mock.call(image='neotys/neoload-loadgenerator:latest', name='lg-6-test-machine', hostname='lg-6-test-machine',
+                           labels={'launched-by-neoload-cli': 'manual'}, detach=True, extra_hosts={}, auto_remove=True,
+                           environment={'NEOLOADWEB_URL': 'http://MyUrl', 'NEOLOADWEB_TOKEN': 'mytoken',
+                                        'ZONE': 'defaultzone'}),
+                 mock.call(image='neotys/neoload-loadgenerator:latest', name='lg-7-test-machine', hostname='lg-7-test-machine',
+                           labels={'launched-by-neoload-cli': 'manual'}, detach=True, extra_hosts={}, auto_remove=True,
+                           environment={'NEOLOADWEB_URL': 'http://MyUrl', 'NEOLOADWEB_TOKEN': 'mytoken',
+                                        'ZONE': 'defaultzone'}),
+                 mock.call(image='neotys/neoload-controller:latest', name='ctrl-6-test-machine', hostname='ctrl-6-test-machine',
+                           labels={'launched-by-neoload-cli': 'manual'}, detach=True,
+                           extra_hosts={'lg-6-test-machine': '172.17.0.1', 'lg-7-test-machine': '172.17.0.2'}, auto_remove=True,
+                           environment={'MODE': 'Managed', 'NEOLOADWEB_URL': 'http://MyUrl',
+                                        'NEOLOADWEB_TOKEN': 'mytoken', 'ZONE': 'defaultzone'})]
+        client_mock.containers.run.assert_has_calls(calls)
+        images_calls = [mock.call('neotys/neoload-loadgenerator:latest'), mock.call('neotys/neoload-controller:latest')]
+        images.get.assert_has_calls(images_calls)
+        images.pull.assert_has_calls(images_calls)
+        assert docker_lib.get_setting(docker_lib.DOCKER_LAUNCHED) == ['lg-6-test-machine', 'lg-7-test-machine', 'ctrl-6-test-machine']
+
+
+    @mock.patch('neoload_cli_lib.config_global.get_config_file', mock.Mock(return_value=tempfile.gettempdir() + "/" + next(tempfile._get_candidate_names())))
+    def test_docker_down(self):
+        mock_client = mock.MagicMock(spec=docker.DockerClient)
+        docker_lib.set_client(mock_client)
+        config_global.reset()
+        docker_lib.add_set(docker_lib.DOCKER_LAUNCHED, ["id_1", "id_2"])
+        mock_id_1 = mock.Mock()
+        mock_id_2 = mock.Mock()
+        mock_client.containers.get.side_effect = lambda k: {'id_1': mock_id_1, 'id_2': mock_id_2}.get(k, 'unhandled request %s' % k)
+        docker_lib.down()
+        mock_id_1.stop.has_called_once()
+        mock_id_2.stop.has_called_once()
+        assert docker_lib.get_setting(docker_lib.DOCKER_LAUNCHED) == []
+
+    def test_max_number(self):
+        client_mock = mock.MagicMock(spec=docker.DockerClient)
+        docker_lib.set_client(client_mock)
+        client_mock.containers.list.return_value = [MockName('lg-1-a'), MockName('lg-2-a'), MockName('dg-3-a')]
+        i = docker_lib.max_number("lg")
+        assert i == 2
+        client_mock.containers.list.assert_has_calls([mock.call(all=True)])
+
+    @mock.patch('neoload_cli_lib.config_global.get_config_file',
+                mock.Mock(return_value=tempfile.gettempdir() + "/" + next(tempfile._get_candidate_names())))
+    @mock.patch('commands.zones.get_zones', mock.Mock(
+        return_value=[{'id': 'aze', 'type': 'STATIC', 'loadgenerators': [], 'controllers': []},
+                      {'id': 'toto', 'type': 'DYNAMIC'}]))
+    def test_start_hook(self):
+        with mock.patch('neoload_cli_lib.docker_lib.start_infra', return_value=None) as mock_method:
+            config_global.reset()
+            config_global.set_attr(docker_lib.DOCKER_ZONE, "aze")
+            docker_lib.hook_test_start({'controllerZoneId': 'aze', 'lgZoneIds': {'aze': 2}})
+            mock_method.assert_has_calls([mock.call('aze', 1, 2, False, None)])
+


### PR DESCRIPTION
## What?
Launch local docker containers to populate static zone in NLWeb.

## Why?
During the demostration, it is easy to demontrate neoload without huge infrastructure.

## How?
Using the Docker API for Python, add a command "neoload docker" with lifecycle subcommands to handle attachment, detachment, preparation (settings only for chain command with "run" to auto setup/teardown), and forget docker settings activities. If docker isn't installed or working properly (ps command doesn't work), that's not our fault and fail any docker-related commands using this quick check.

This feature has configuration: 
this is default configuration 

'docker.controller.image': 'neotys/neoload-controller:latest',
'docker.controller.default_count': 1,
'docker.lg.image': 'neotys/neoload-loadgenerator:latest',
'docker.lg.default_count': 2,
'docker.zone': 'defaultzone'

up/down  ->up launch controller and load generation according to configuration, down stop the launched container
install/uninstall -> add the triggering of docker feature before run a test to deploy infrastructure. This trigger work when the controller zone set in docker  is the same than controller zone set in the test..
status -> display relevant information of docker feature: configuration, launcher containers, hooks status, and image is pulled.
forget -> forget all launched container, it could be usefull when you have used up and you want use another container.
clean -> remove all launcher container with neoload cli.

## Testing
This is made by unit test with mock.

## Supportability
We can explicitly call out that this is not the preferred production way to handle infra at large scale, but rather use dynamic infra or existing static zones. Since we do not support the customers local docker deployment or the Docker API libraries, it should be considered as "use for local development and at-your-own-risk". Support should not be troubleshooting the world of Docker on Windows and all it's faults. If the user can run a command line such as "docker ps" and get back non-error results, our docker command should work for experimental activities (such as sanity checks and CI when no infra is available).