### PR TITLE
Set command for report command user agent

### DIFF
--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -55,6 +55,7 @@ def cli(template, json_in, out_file, filter, report_type, name):
     See more templates, examples, filters with "neoload report"
     """
 
+    rest_crud.set_current_command()
     if all(v is None for v in [template,json_in,out_file,filter]):
         print_extended_help()
         tools.system_exit({'code':1,'message':''})


### PR DESCRIPTION
## What?
Fix issue with the user agent for the report command
Actual user agent:        NeoloadCli/dev-interactive//
Expected user agent:    NeoloadCli/dev-interactive/report/
