### PR TITLE
Add QA scripts to test the CLI on a real NLW

### DIFF
--- a/tests/integration/expected/fastfail.log
+++ b/tests/integration/expected/fastfail.log
@@ -1,0 +1,4 @@
+fastfail started: 2020-07-28 17:10:13.205939
+Initializing
+Runningfastfail ended: 2020-07-28 17:12:29.265118
+0 hard SLA failures, test status TERMINATED,PASSED

--- a/tests/integration/expected/junit-sla.xml
+++ b/tests/integration/expected/junit-sla.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<testsuites failures="1" errors="0" tests="4" disabled="0" time="0.0">
+	<testsuite name="com.neotys.Global" disabled="0" failures="0" errors="0" skipped="0" time="0" tests="1">
+		<testcase name="error-rate" classname="com.neotys.Global"/>
+	</testsuite>
+	<testsuite name="com.neotys.REQUEST.PerRun.simpledemo" disabled="0" failures="0" errors="0" skipped="0" time="0" tests="1">
+		<testcase name="error-rate" classname="com.neotys.REQUEST.PerRun.simpledemo"/>
+	</testsuite>
+	<testsuite name="com.neotys.REQUEST.PerInterval.simpledemo" disabled="0" failures="1" errors="0" skipped="0" time="0" tests="1">
+		<testcase name="avg-elt-per-sec" classname="com.neotys.REQUEST.PerInterval.simpledemo">
+			<failure type="NeoLoad SLA" message="SLA failed">Container: /&lt;br/&gt;Path: User Paths &gt; simpledemo &gt; Init &gt; Actions &gt; /&lt;br/&gt;Virtual User: simpledemo&lt;br/&gt;SLA Profile: REQUEST&lt;br/&gt;SLA Type: Per Interval&lt;br/&gt;WARNING Type: avg-elt-per-sec&lt;br/&gt;Project: NeoLoad-CLI-simpledemo&lt;br/&gt;Scenario: simpledemo&lt;br/&gt;&lt;br/&gt;WARNING&lt;br/&gt;description: if the avg-elt-per-sec &gt;=  then fail&lt;br/&gt;&lt;br/&gt;Results: &lt;br/&gt;&lt;br/&gt;avg-elt-per-sec=100.0%&lt;br/&gt;&lt;br/&gt;Created N/A&lt;br/&gt;</failure>
+		</testcase>
+	</testsuite>
+	<testsuite name="com.neotys.REQUEST.PerInterval.simpledemo" disabled="0" failures="0" errors="0" skipped="0" time="0" tests="1">
+		<testcase name="avg-resp-time" classname="com.neotys.REQUEST.PerInterval.simpledemo"/>
+	</testsuite>
+</testsuites>

--- a/tests/integration/expected/run.log
+++ b/tests/integration/expected/run.log
@@ -1,0 +1,50 @@
+Results of  : eafdde40-9a12-4a36-9319-f624f72bc245
+Logs are available at http://localhost:8080#!result/eafdde40-9a12-4a36-9319-f624f72bc245/overview
+Status: INIT
+Status: RUNNING
+    00:00:11/00:01:00  Err[--], LGs[1]         VUs:6   BPS[66201.6]    RPS:5.005       avg(rql): 113
+    00:00:31/00:01:00  Err[--], LGs[1]         VUs:16  BPS[186161.1]   RPS:12.024      avg(rql): 107
+    00:00:51/00:01:00  Err[--], LGs[1]         VUs:20  BPS[291785.53]  RPS:17.000      avg(rql): 106
+Status: TERMINATED
+SLA summary:
+GlobalSLA [error-rate] PASSED on []
+
+PerRunSLA [error-rate] PASSED on [simpledemo > Actions > /]
+
+PerIntervalSLA [avg-elt-per-sec] WARNING on [simpledemo > Actions > / [100.000% >= ]]
+PerIntervalSLA [avg-resp-time] PASSED on [simpledemo > Actions > /]
+
+{
+  "result": {
+    "id": "eafdde40-9a12-4a36-9319-f624f72bc245",
+    "name": "CLI-1",
+    "description": "",
+    "author": "Luke Skywalker",
+    "terminationReason": "POLICY",
+    "lgCount": 1,
+    "project": "NeoLoad-CLI-simpledemo",
+    "scenario": "simpledemo",
+    "status": "TERMINATED",
+    "qualityStatus": "PASSED",
+    "startDate": 1590771663205,
+    "endDate": 1590771724404,
+    "duration": 61199,
+    "testId": "b1e7e208-e858-435a-b142-de76b7882b6b"
+  },
+  "statistics": {
+    "totalRequestCountSuccess": 119,
+    "totalRequestCountFailure": 0,
+    "totalRequestDurationAverage": 1373.5798,
+    "totalRequestCountPerSecond": 1.9444762,
+    "totalTransactionCountSuccess": 116,
+    "totalTransactionCountFailure": 0,
+    "totalTransactionDurationAverage": 1370.8362,
+    "totalTransactionCountPerSecond": 1.8954558,
+    "totalIterationCountSuccess": 114,
+    "totalIterationCountFailure": 0,
+    "totalGlobalDownloadedBytes": 536537,
+    "totalGlobalDownloadedBytesPerSecond": 8767.088,
+    "totalGlobalCountFailure": 0
+  }
+}
+Test completed.

--- a/tests/integration/expected/summary.txt
+++ b/tests/integration/expected/summary.txt
@@ -1,0 +1,42 @@
+SLA summary:
+GlobalSLA [error-rate] PASSED on []
+
+PerRunSLA [error-rate] PASSED on [simpledemo > Actions > /]
+
+PerIntervalSLA [avg-elt-per-sec] WARNING on [simpledemo > Actions > / [100.000% >= ]]
+PerIntervalSLA [avg-resp-time] PASSED on [simpledemo > Actions > /]
+
+{
+  "result": {
+    "id": "6683db1e-a7ff-491e-847b-f263a8460892",
+    "name": "SLA test renamed2",
+    "description": "",
+    "author": "Luke Skywalker",
+    "terminationReason": "POLICY",
+    "lgCount": 1,
+    "project": "NeoLoad-CLI-simpledemo",
+    "scenario": "simpledemo",
+    "status": "TERMINATED",
+    "qualityStatus": "PASSED",
+    "startDate": 1595933846905,
+    "endDate": 1595933907195,
+    "duration": 60290,
+    "testId": "c31fb9b6-046f-4176-87c8-1bc9bbac9b60"
+  },
+  "statistics": {
+    "totalRequestCountSuccess": 740,
+    "totalRequestCountFailure": 0,
+    "totalRequestDurationAverage": 116.58784,
+    "totalRequestCountPerSecond": 12.274009,
+    "totalTransactionCountSuccess": 0,
+    "totalTransactionCountFailure": 0,
+    "totalTransactionDurationAverage": 0,
+    "totalTransactionCountPerSecond": 0.0,
+    "totalIterationCountSuccess": 720,
+    "totalIterationCountFailure": 0,
+    "totalGlobalDownloadedBytes": 20024444,
+    "totalGlobalDownloadedBytesPerSecond": 332135.4,
+    "totalGlobalCountFailure": 0
+  }
+}
+Test completed.

--- a/tests/integration/runAllScripts.sh
+++ b/tests/integration/runAllScripts.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+if [ "$#" -ne 3 ]; then
+  echo "Need 3 arguments and need to be launched from the root of the repo." >&2
+  echo "Example : ./tests/integration/runAllScripts.sh https://nlwonprem253-wks-onprem.neotys.com/ abcdeftokentokentoken defaultzone" >&2
+  echo "The URL must point at a NLWeb with a valid license installed, and at least 1 controller and 1 LG on the provided zone." >&2
+  echo "The token must be luke on Jedi1 for internal stack" >&2
+  exit 1
+fi
+
+fails=0
+workspaceName='CLI'
+runApiV2Tests=false
+uid=$(date +%s)
+
+if [ "$runApiV2Tests" = true ]; then
+  # Test API V2 without workspaces
+  python neoload login --url $1 $2
+  tests/integration/scripts/run.test.sh $uid $3 ; fails=$(( $? + $fails ))
+  tests/integration/scripts/run.fastfail.test.sh $uid $3 ; fails=$(( $? + $fails ))
+  tests/integration/scripts/wait.test.sh $uid $3 ; fails=$(( $? + $fails ))
+  tests/integration/scripts/run.oneliner.test.sh $uid $3 ; fails=$(( $? + $fails ))
+  tests/integration/scripts/results.put.test.sh ; fails=$(( $? + $fails ))
+  tests/integration/scripts/results.delete.test.sh ; fails=$(( $? + $fails ))
+  tests/integration/scripts/settings.create.delete.test.sh $uid ; fails=$(( $? + $fails ))
+  tests/integration/scripts/settings.patch.test.sh $uid ; fails=$(( $? + $fails ))
+  tests/integration/scripts/settings.put.test.sh $uid ; fails=$(( $? + $fails ))
+  tests/integration/scripts/zones.ls.test.sh $uid ; fails=$(( $? + $fails ))
+  tests/integration/scripts/project.upload.test.sh $uid ; fails=$(( $? + $fails ))
+  tests/integration/scripts/validate.test.sh ; fails=$(( $? + $fails ))
+
+  echo "======  Cleanup test settings and test results  ======"
+  if [ $fails -eq 0 ]; then
+    tests/integration/scripts/cleanup.sh $uid $1 $2
+  else
+    echo "[WARNING] - Cleanup skipped because there is failures."
+    echo "[WARNING] - To cleanup manually, run  ./tests/integration/scripts/cleanup.sh $uid [NLW api url] [your NLW token]"
+  fi
+  echo ""
+fi
+
+
+
+# Test API V3 with a particular workspace
+python neoload login --workspace $workspaceName --url $1 $2
+tests/integration/scripts/run.test.sh $uid $3 ; fails=$(( $? + $fails ))
+tests/integration/scripts/run.fastfail.test.sh $uid $3 ; fails=$(( $? + $fails ))
+tests/integration/scripts/run.oneliner.test.sh $uid $3 ; fails=$(( $? + $fails ))
+tests/integration/scripts/wait.test.sh $uid $3 ; fails=$(( $? + $fails ))
+tests/integration/scripts/results.put.test.sh ; fails=$(( $? + $fails ))
+tests/integration/scripts/results.delete.test.sh ; fails=$(( $? + $fails ))
+tests/integration/scripts/settings.create.delete.test.sh $uid ; fails=$(( $? + $fails ))
+tests/integration/scripts/settings.patch.test.sh $uid ; fails=$(( $? + $fails ))
+tests/integration/scripts/settings.put.test.sh $uid ; fails=$(( $? + $fails ))
+tests/integration/scripts/zones.ls.test.sh $uid ; fails=$(( $? + $fails ))
+tests/integration/scripts/project.upload.test.sh $uid ; fails=$(( $? + $fails ))
+tests/integration/scripts/validate.test.sh ; fails=$(( $? + $fails ))
+
+echo "There are $fails failures"
+echo ""
+
+echo "======  Cleanup test settings and test results  ======"
+if [ $fails -eq 0 ]; then
+  tests/integration/scripts/cleanup.sh $uid $1 $2 $workspaceName
+else
+  echo "[WARNING] - Cleanup skipped because there is failures."
+  echo "[WARNING] - To cleanup manually, run  ./tests/integration/scripts/cleanup.sh $uid [NLW api url] [your NLW token]"
+fi
+echo ""
+
+echo "======  Manually check that these commands does not throw an error  ======"
+echo "_____________________________"
+echo "Status is:"
+python neoload status
+echo "_____________________________"
+echo "Logout:"
+python neoload logout
+echo "_____________________________"
+echo "Status when logged out is:"
+python neoload status
+echo "_____________________________"
+echo "Version is:"
+python neoload --version
+echo "_____________________________"
+echo "Help is:"
+python neoload --help
+
+exit $fails

--- a/tests/integration/scripts/cleanup.sh
+++ b/tests/integration/scripts/cleanup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# First Parameter is The uid of the url
+# Second Parameter is Neoload API URL
+# Third parameter is Neoload API Token
+# Fourth parameter is the workspace name (or empty for default workspace)
+
+fails=0
+uid=$1
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+if [ "$#" -lt 4 ]; then
+  python neoload login --url $2 $3
+else
+  python neoload login --workspace $4 --url $2 $3
+fi
+
+
+# Delete the settings and associated results
+cmd='python neoload test-settings delete "Test settings CLI to wait ${uid}"'
+out=`eval $cmd`
+assertJsonEquals '.name' "\"Test settings CLI to wait ${uid}\""
+
+
+cmd='python neoload test-settings delete "Test settings CLI for project ${uid}"'
+out=`eval $cmd`
+assertJsonEquals '.name' "\"Test settings CLI for project ${uid}\""
+
+
+cmd='python neoload test-settings delete "Test settings CLI to run ${uid}"'
+out=`eval $cmd`
+assertJsonEquals '.name' "\"Test settings CLI to run ${uid}\""
+
+
+cmd='python neoload test-settings delete "Test settings CLI to run (readme) ${uid}"'
+out=`eval $cmd`
+assertJsonEquals '.name' "\"Test settings CLI to run (readme) ${uid}\""
+
+
+cmd='python neoload test-settings delete "Test settings CLI to run fastfail ${uid}"'
+out=`eval $cmd`
+assertJsonEquals '.name' "\"Test settings CLI to run fastfail ${uid}\""
+
+
+exit $fails

--- a/tests/integration/scripts/project.upload.test.sh
+++ b/tests/integration/scripts/project.upload.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Create a settings
+cmd='python neoload test-settings create "Test settings CLI for project ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI for project ${uid}\""
+assertJsonEquals '.description' null
+
+
+# Upload zip
+cmd='python neoload project --path tests/neoload_projects/example_1.zip upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-example-2_0"'
+assertJsonEquals '.asCodeFiles[0].path' '"example_1/default.yaml"'
+assertJsonEquals '.asCodeFiles[0].includes[0]' '"paths/geosearch_get.yaml"'
+assertJsonEquals '.asCodeFiles[1].path' '"example_1/paths/geosearch_get.yaml"'
+assertJsonEquals '.scenarios[0].scenarioName' '"sanityScenario"'
+assertJsonEquals '.scenarios[0].scenarioSource' '"example_1/default.yaml"'
+assertJsonEquals '.scenarios[1].scenarioName' '"slaMinScenario"'
+assertJsonEquals '.scenarios[2].scenarioName' '"fullTest"'
+
+
+# Upload yml
+cmd='python neoload project --path tests/neoload_projects/simpledemo.yml upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-simpledemo"'
+assertJsonEquals '.scenarios[0].scenarioName' '"simpledemo"'
+assertJsonEquals '.asCodeFiles[0].path' '"simpledemo.yml"'
+assertJsonEquals '.scenarios[0].scenarioSource' '"simpledemo.yml"'
+
+
+# Upload folder
+cmd='python neoload project --path tests/neoload_projects/example_1 upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-example-2_0"'
+assertJsonEquals '.asCodeFiles[0].path' '"default.yaml"'
+assertJsonEquals '.asCodeFiles[0].includes[0]' '"paths/geosearch_get.yaml"'
+assertJsonEquals '.asCodeFiles[1].path' '"slas/uat.yaml"'
+assertJsonEquals '.scenarios[0].scenarioName' '"sanityScenario"'
+assertJsonEquals '.scenarios[0].scenarioSource' '"default.yaml"'
+assertJsonEquals '.scenarios[1].scenarioName' '"slaMinScenario"'
+assertJsonEquals '.scenarios[2].scenarioName' '"fullTest"'
+
+
+exit $fails

--- a/tests/integration/scripts/results.delete.test.sh
+++ b/tests/integration/scripts/results.delete.test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+fails=0
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Use
+cmd='python neoload test-results use "CLI-wait-1"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+echo $out
+echo "[DONE] $cmd"
+
+
+# Delete
+cmd='python neoload test-results delete'
+out=`eval $cmd`
+assertEquals "$?" '0'
+echo $out
+echo "[DONE] $cmd"
+
+exit $fails

--- a/tests/integration/scripts/results.put.test.sh
+++ b/tests/integration/scripts/results.put.test.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+fails=0
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Ls
+cmd='python neoload test-results ls "CLI-1"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+resultId=`echo $out | jq .id`
+assertJsonEquals '.name' '"CLI-1"'
+assertJsonEquals '.description' '""'
+assertJsonEquals '.qualityStatus' '"PASSED"'
+
+
+# Use
+cmd='python neoload test-results use "CLI-1"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+echo $out
+echo "[DONE] $cmd"
+
+
+# Put all fields
+cmd='python neoload test-results --rename "SLA test renamed" --description "some desc" --quality-status FAILED put'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.id' "${resultId}"
+assertJsonEquals '.name' '"SLA test renamed"'
+assertJsonEquals '.description' '"some desc"'
+assertJsonEquals '.qualityStatus' '"FAILED"'
+
+
+# Put only required fields
+cmd='python neoload test-results --rename "SLA test renamed2" --quality-status PASSED put'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.id' "${resultId}"
+assertJsonEquals '.name' '"SLA test renamed2"'
+assertJsonEquals '.description' '""'
+assertJsonEquals '.qualityStatus' '"PASSED"'
+
+
+# Summary
+cmd='python neoload test-results summary'
+out=`eval $cmd > summary.txt`
+assertEquals "$?" '0'
+echo ""
+echo "[DONE]" $cmd "Write output to file summary.txt"
+echo ">>> You MUST check manually that the differences below are ONLY IDs and numbers !!"
+diff summary.txt tests/integration/expected/summary.txt
+echo ""
+rm -f summary.txt
+
+
+# Junit-SLA
+cmd='python neoload test-results junitsla'
+out=`eval $cmd`
+assertEquals "$?" '0'
+echo ""
+echo "[DONE]" $cmd "Write output to file junit-sla.xml"
+echo ">>> You MUST check manually that the differences below are ONLY IDs and numbers !!"
+diff junit-sla.xml tests/integration/expected/junit-sla.xml
+echo ""
+rm -f junit-sla.xml
+
+
+# Junit-SLA with file name
+cmd='python neoload test-results --junit-file junit.xml junitsla'
+out=`eval $cmd`
+assertEquals "$?" '0'
+echo ""
+echo "[DONE]" $cmd "Write output to file junit.xml"
+echo ">>> You MUST check manually that the differences below are ONLY IDs and numbers !!"
+diff junit.xml tests/integration/expected/junit-sla.xml
+echo ""
+rm -f junit.xml
+
+exit $fails

--- a/tests/integration/scripts/run.fastfail.test.sh
+++ b/tests/integration/scripts/run.fastfail.test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+zonewithresources=$2
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Create a settings
+cmd='python neoload test-settings --zone ${zonewithresources} --scenario some_scenario --naming-pattern "CLI-fastfail-\${runID}" create "Test settings CLI to run fastfail ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI to run fastfail ${uid}\""
+assertJsonEquals '.description' null
+assertJsonEquals '.scenarioName' '"some_scenario"'
+assertJsonEquals '.testResultNamingPattern' '"CLI-fastfail-${runID}"'
+assertJsonEquals ".lgZoneIds.${zonewithresources}" 1
+assertJsonEquals '.controllerZoneId' "\"${zonewithresources}\""
+
+
+# Upload a project
+cmd='python neoload project --path tests/neoload_projects/simpledemo.yml upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-simpledemo"'
+assertJsonEquals '.scenarios[0].scenarioName' '"simpledemo"'
+
+
+# Run the test
+cmd='python neoload run -d --scenario simpledemo'
+out=`eval $cmd`
+assertEquals "$?" '0'
+
+
+# Fastfail
+cmd='python neoload fastfail --max-failure 0 slas cur'
+out=`eval $cmd > fastfail.log`
+assertEquals "$?" '0'
+echo "[DONE]" $cmd "Write output to file fastfail.log"
+echo ">>> You MUST check manually that the differences below are ONLY the dates !"
+diff fastfail.log tests/integration/expected/fastfail.log
+rm -f fastfail.log
+
+exit $fails

--- a/tests/integration/scripts/run.oneliner.test.sh
+++ b/tests/integration/scripts/run.oneliner.test.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+zonewithresources=$2
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Readme TL;DR command : Create a settings, upload project, run the test
+cmd='python neoload test-settings --zone ${zonewithresources} --lgs 1 --scenario simpledemo --naming-pattern "CLI-\${runID}" createorpatch "Test settings CLI to run (readme) ${uid}" project --path tests/neoload_projects/simpledemo.yml upload "Test settings CLI to run (readme) ${uid}" run'
+out=`eval $cmd`
+assertEquals "$?" '0'
+
+exit $fails

--- a/tests/integration/scripts/run.test.sh
+++ b/tests/integration/scripts/run.test.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+zonewithresources=$2
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+
+# Create a settings
+cmd='python neoload test-settings --zone ${zonewithresources} --scenario some_scenario --naming-pattern "CLI-\${runID}" create "Test settings CLI to run ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI to run ${uid}\""
+assertJsonEquals '.description' null
+assertJsonEquals '.scenarioName' '"some_scenario"'
+assertJsonEquals '.testResultNamingPattern' '"CLI-${runID}"'
+assertJsonEquals ".lgZoneIds.${zonewithresources}" 1
+assertJsonEquals '.controllerZoneId' "\"${zonewithresources}\""
+
+
+# Upload a project
+cmd='python neoload project --path tests/neoload_projects/simpledemo.yml upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-simpledemo"'
+assertJsonEquals '.scenarios[0].scenarioName' '"simpledemo"'
+
+
+# Run the test
+cmd='python neoload run --scenario simpledemo'
+out=`eval $cmd > run.log`
+assertEquals "$?" '0'
+echo "[DONE]" $cmd "Write output to file run.log"
+echo ">>> You MUST check manually that the differences below are ONLY IDs and numbers !!"
+diff run.log tests/integration/expected/run.log
+rm -f run.log
+
+exit $fails

--- a/tests/integration/scripts/settings.create.delete.test.sh
+++ b/tests/integration/scripts/settings.create.delete.test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Create
+cmd='python neoload test-settings create "Test settings CLI ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI ${uid}\""
+assertJsonEquals '.description' null
+assertJsonEquals '.testResultNamingPattern' '"#${runID}"'
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+
+
+# List
+cmd='python neoload test-settings ls'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].name' "\"Test settings CLI ${uid}\""
+
+
+# Create a test to delete
+cmd='python neoload test-settings --description "desc" --scenario "scenario1" --zone "myzone" --lgs 3 --naming-pattern "MyRunNumber\${runID}" create "Test settings CLI_2 ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+testToDeleteId=`echo $out | jq .id`
+assertJsonEquals '.name' "\"Test settings CLI_2 ${uid}\""
+assertJsonEquals '.scenarioName' '"scenario1"'
+assertJsonEquals '.description' '"desc"'
+assertJsonEquals '.lgZoneIds.myzone' 3
+assertJsonEquals '.controllerZoneId' '"myzone"'
+assertJsonEquals '.testResultNamingPattern' '"MyRunNumber${runID}"'
+
+
+# List
+cmd='python neoload test-settings ls'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].name' "\"Test settings CLI_2 ${uid}\""
+
+
+# Create all fields
+cmd='python neoload test-settings --zone "myzone" create "Test settings CLI_3 ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI_3 ${uid}\""
+assertJsonEquals '.scenarioName' null
+assertJsonEquals '.description' null
+assertJsonEquals '.lgZoneIds.myzone' 1
+assertJsonEquals '.controllerZoneId' '"myzone"'
+assertJsonEquals '.testResultNamingPattern' '"#${runID}"'
+
+
+# Delete
+cmd='python neoload test-settings delete'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI_3 ${uid}\""
+
+
+# Delete with name
+cmd='python neoload test-settings delete "Test settings CLI ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI ${uid}\""
+
+
+# Delete with id
+cmd="python neoload test-settings delete ${testToDeleteId}"
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI_2 ${uid}\""
+
+exit $fails

--- a/tests/integration/scripts/settings.patch.test.sh
+++ b/tests/integration/scripts/settings.patch.test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Create the test with "createorpatch"
+cmd='python neoload test-settings createorpatch "Test settings CLI patch ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch ${uid}\""
+assertJsonEquals '.scenarioName' null
+assertJsonEquals '.description' null
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"#${runID}"'
+
+
+# Patch the test with "createorpatch". Nothing should be modified
+cmd='python neoload test-settings createorpatch "Test settings CLI patch ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch ${uid}\""
+assertJsonEquals '.scenarioName' '""'
+assertJsonEquals '.description' '""'
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"#${runID}"'
+
+
+# Patch name scenario description pattern
+cmd='python neoload test-settings --rename "Test settings CLI patch2 ${uid}" --scenario newScenario --description "my desc" --naming-pattern "pattern" patch'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch2 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Patch lgs
+cmd='python neoload test-settings --lgs 3 patch'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch2 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.defaultzone' 3
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Patch lgs
+cmd='python neoload test-settings --lgs zone:3,zone2:4 patch'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch2 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.zone' 3
+assertJsonEquals '.lgZoneIds.zone2' 4
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Patch zone
+cmd='python neoload test-settings --zone myZone patch'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch2 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.zone' 3
+assertJsonEquals '.lgZoneIds.zone2' 4
+assertJsonEquals '.lgZoneIds.myZone' null
+assertJsonEquals '.controllerZoneId' '"myZone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Patch name
+cmd='python neoload test-settings --rename "Test settings CLI patch3 ${uid}" patch'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch3 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.zone' 3
+assertJsonEquals '.lgZoneIds.zone2' 4
+assertJsonEquals '.lgZoneIds.myZone' null
+assertJsonEquals '.controllerZoneId' '"myZone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Delete
+cmd='python neoload test-settings delete "Test settings CLI patch3 ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch3 ${uid}\""
+
+exit $fails

--- a/tests/integration/scripts/settings.put.test.sh
+++ b/tests/integration/scripts/settings.put.test.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Create
+cmd='python neoload test-settings create "Test settings CLI put ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI put ${uid}\""
+assertJsonEquals '.scenarioName' null
+assertJsonEquals '.description' null
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '"#${runID}"'
+
+
+# Put all fields
+cmd='python neoload test-settings --rename "Test settings CLI patch2 ${uid}" --scenario newScenario --description "my desc"  --zone myZone --lgs myZone:3,myZone2:50 --naming-pattern "pattern" put'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI patch2 ${uid}\""
+assertJsonEquals '.scenarioName' '"newScenario"'
+assertJsonEquals '.description' '"my desc"'
+assertJsonEquals '.lgZoneIds.defaultzone' null
+assertJsonEquals '.lgZoneIds.myZone' 3
+assertJsonEquals '.lgZoneIds.myZone2' 50
+assertJsonEquals '.controllerZoneId' '"myZone"'
+assertJsonEquals '.testResultNamingPattern' '"pattern"'
+
+
+# Put only required fields
+cmd='python neoload test-settings --rename "Test settings CLI put2 ${uid}" put'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI put2 ${uid}\""
+assertJsonEquals '.scenarioName' '""'
+assertJsonEquals '.description' '""'
+assertJsonEquals '.lgZoneIds.defaultzone' 1
+assertJsonEquals '.lgZoneIds.myZone' null
+assertJsonEquals '.lgZoneIds.myZone2' null
+assertJsonEquals '.controllerZoneId' '"defaultzone"'
+assertJsonEquals '.testResultNamingPattern' '""'
+
+
+# Delete
+cmd='python neoload test-settings delete "Test settings CLI put2 ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI put2 ${uid}\""
+
+exit $fails

--- a/tests/integration/scripts/validate.test.sh
+++ b/tests/integration/scripts/validate.test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+fails=0
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+cmd='python neoload validate tests/neoload_projects/example_1'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertEquals "$out" 'All yaml files underneath the path provided are valid.'
+
+
+cmd='python neoload validate tests/neoload_projects/example_1/default.yaml'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertEquals "$out" 'Yaml file is valid.'
+
+
+cmd='python neoload validate tests/neoload_projects/invalid_to_schema.yaml'
+out=`eval $cmd`
+assertEquals "$?" '1'
+
+exit $fails

--- a/tests/integration/scripts/wait.test.sh
+++ b/tests/integration/scripts/wait.test.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+fails=0
+uid=$1
+zonewithresources=$2
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+
+# Create a settings
+cmd='python neoload test-settings --zone ${zonewithresources} --scenario sanityScenario --naming-pattern "CLI-wait-\${runID}" create "Test settings CLI to wait ${uid}"'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.name' "\"Test settings CLI to wait ${uid}\""
+assertJsonEquals '.description' null
+assertJsonEquals '.scenarioName' '"sanityScenario"'
+assertJsonEquals '.testResultNamingPattern' '"CLI-wait-${runID}"'
+assertJsonEquals ".lgZoneIds.${zonewithresources}" 1
+assertJsonEquals '.controllerZoneId' "\"${zonewithresources}\""
+
+
+# Upload a project
+cmd='python neoload project --path tests/neoload_projects/simpledemo.yml upload'
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.projectName' '"NeoLoad-CLI-simpledemo"'
+assertJsonEquals '.scenarios[0].scenarioName' '"simpledemo"'
+
+
+# Run the test with detach
+cmd='python neoload run --scenario simpledemo -d'
+out=`eval $cmd`
+assertEquals "$?" '0'
+runningTestId=`echo $out | jq .resultId`
+assertJsonEquals '.resultId' "${runningTestId}"
+
+
+# Wait for the end of the test
+cmd="python neoload wait ${runningTestId}"
+sleep 2
+out=`eval $cmd > wait.log`
+assertEquals "$?" '0'
+echo "[DONE]" $cmd "Write log to file wait.log"
+echo ">>> You MUST check manually that the differences below are ONLY IDs and numbers !!"
+diff wait.log tests/integration/expected/run.log
+rm -f waitlog
+
+
+# TODO the following command does not find the test result (by its name) : python neoload wait "Name Of The Test"
+
+exit $fails

--- a/tests/integration/scripts/zones.ls.test.sh
+++ b/tests/integration/scripts/zones.ls.test.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+fails=0
+
+assertJsonEquals () {
+  if [ "$(echo $out | jq $1)" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but jq '$1' was: $(echo $out | jq $1)"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+assertEquals () {
+  if [ "$1" != "$2" ]; then
+    echo "[FAILURE] [${0##*/}] $cmd"
+	echo "   Expected: $2"
+	echo "   but was: $1"
+	fails=$(( 1 + $fails ))
+  else
+    echo "[SUCCESS] $cmd"
+  fi
+}
+
+
+# Ls
+cmd='python neoload zones'
+out=`eval $cmd`
+assertEquals "$?" '0'
+firstZoneId=`echo $out | jq .[0].id`
+firstZoneName=`echo $out | jq .[0].name`
+firstZoneType=`echo $out | jq .[0].type`
+
+
+# Ls one zone by id
+cmd="python neoload zones ${firstZoneId}"
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].id' "${firstZoneId}"
+assertJsonEquals '.[0].name' "${firstZoneName}"
+assertJsonEquals '.[0].type' "${firstZoneType}"
+
+
+# Ls one zone by name
+cmd="python neoload zones ${firstZoneName}"
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].id' "${firstZoneId}"
+assertJsonEquals '.[0].name' "${firstZoneName}"
+assertJsonEquals '.[0].type' "${firstZoneType}"
+
+
+# Ls static zones
+cmd="python neoload zones --static"
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].type' '"STATIC"'
+
+
+# Ls dynamic zones
+cmd="python neoload zones --dynamic"
+out=`eval $cmd`
+assertEquals "$?" '0'
+assertJsonEquals '.[0].type' '"DYNAMIC"'
+
+exit $fails


### PR DESCRIPTION
## What?
Scripts that runs on a real NLW with url and token configured in this repository settings secrets.

## Why?
To have actual command tests that are the most close to a real usage of the CLI.