### PR TITLE
Convert entity property values to string before filter compare

### DIFF
--- a/neoload/neoload_cli_lib/filtering.py
+++ b/neoload/neoload_cli_lib/filtering.py
@@ -1,6 +1,5 @@
 import re
 
-
 def parse_filters(filter_spec, allowed_api_query_params):
     """
     Reads the filter_spec and return the filters that can be applied with public API
@@ -41,8 +40,8 @@ def remove_by_filter(all_entities, cli_params):
 def entity_matches_all_filters(entity, filters):
     for key in filters.keys():
         if key in entity:
-            find_re = filters[key]
-            in_val = entity[key]
+            find_re = filters[key] # filter value is always a string from shell arguments
+            in_val = str(entity[key]) # value from API entities might not always be string
             if not re.search(find_re, in_val):
                 return False
         else:

--- a/tests/neoload_cli_lib/test_filtering.py
+++ b/tests/neoload_cli_lib/test_filtering.py
@@ -10,10 +10,11 @@ class TestFiltering:
         assert cli_params['description'] == 'a word'
 
     def test_remove_by_filter(self):
-        cli_params = {'description': 'a word'}
+        cli_params = {'description': 'a word', 'int': '6'}
         all_elements = [{"id": "someId", "name": "elementWithouDescription"},
-                        {"id": "someId", "name": "toto", "description": "a word"},
-                        {"id": "someId", "name": "notMe", "description": ".... "}]
+                        {"id": "someId", "name": "toto", "description": "a word", "int": 6},
+                        {"id": "someId", "name": "notMe", "description": ".... "},
+                        {"id": "someId", "name": "numeric", "int": 5}]
         filtered_elements = filtering.remove_by_filter(all_elements, cli_params)
         assert len(filtered_elements) == 1
-        assert filtered_elements[0] == {"id": "someId", "name": "toto", "description": "a word"}
+        assert filtered_elements[0] == {"id": "someId", "name": "toto", "description": "a word", "int": 6}


### PR DESCRIPTION
## What?
Fix bug when filtering on non-API-parameter entity-specific properties

## Why?
Prior examples assumed that all properties on entities coming back from API JSON were strings. Properties such as lgCount, startDate, and duration are numerics. During demo, customer wanted to filter based on lgCount in order to know which were true sanity checks beyond the scenario and project names.

## How?
Wrap entity[key] with str() method.

## Testing
Updated params and entity specs in: tests/neoload_cli_lib/test_filtering.py::TestFiltering::test_remove_by_filter