### PR TITLE
Update ls to use internal filtering b/c endpoint not implemented; tes…

### DIFF
--- a/neoload/commands/workspaces.py
+++ b/neoload/commands/workspaces.py
@@ -30,9 +30,9 @@ def cli(command, name_or_id):
     # avoid to make two requests if we have not id.
     if command == "ls":
         # The endpoint GET /workspaces/{workspaceId} is not yet implemented
-        if name_or_id is not None:
-            print("ERROR: Unable to display only one workspace. API endoint not yet implemented. Please use command neoload workspaces ls without name or ID")
-        tools.ls(name_or_id, is_id, __resolver)
+        filter = None
+        if name_or_id is not None: filter = "id={}".format(name_or_id)
+        tools.ls(None, True, __resolver, filter)
         return
 
     __id = tools.get_id(name_or_id, __resolver, is_id)

--- a/tests/commands/workspaces/test_workspace_ls.py
+++ b/tests/commands/workspaces/test_workspace_ls.py
@@ -22,9 +22,12 @@ class TestWorkspaceLs:
 
     def test_list_one(self, monkeypatch, valid_data):
         runner = CliRunner()
+        mock_api_get_with_pagination(monkeypatch, 'v3/workspaces',
+                     '[{"id":"'+valid_data.default_workspace_id+'", "name":"19377", "description":".... "}]')
         result = runner.invoke(workspaces, ['ls', valid_data.default_workspace_id])
-        assert result.exit_code == 1
-        assert 'ERROR: Unable to display only one workspace. API endoint not yet implemented' in result.output
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert len(json_result)==1
 
     def test_error_not_logged_in(self):
         runner = CliRunner()


### PR DESCRIPTION
## What?
Fix workspaces ls [id] so that 'ls' command does not try to use not-yet-implemented API endpoint and stall (tests).

## Why?
Because pytest suite is getting hung up on tests/commands/workspaces/test_workspace_ls.py::TestWorkspaceLs::test_list_one

## How?
Replace call to use built-in name_or_id translation with internal filter method developed last year.

## Testing
Updated tests/commands/workspaces/test_workspace_ls.py::TestWorkspaceLs::test_list_one to mock same data as what's being asked/filtered for.