### PR TITLE
Fix validate command from as-code training outcomes

### DIFF
--- a/neoload/commands/validate.py
+++ b/neoload/commands/validate.py
@@ -13,6 +13,10 @@ from neoload_cli_lib.schema_validation import __default_schema_url
 def cli(file, refresh, schema_url, ssl_cert):
     """Verify that the yaml FILE matches the neoload as-code file format"""
 
+    force_schema = os.environ.get('NLCLI_FORCE_SCHEMA')
+    if force_schema is not None and len(force_schema) > 0:
+        schema_url = force_schema
+
     path = os.path.abspath(file)
     try:
         if os.path.isdir(path):

--- a/neoload/version.py
+++ b/neoload/version.py
@@ -1,1 +1,1 @@
-__version__ = None
+__version__ = "1.2.2.dev0+g9f44209.d20210302"

--- a/resources/as-code.latest.schema.json
+++ b/resources/as-code.latest.schema.json
@@ -81,7 +81,7 @@
 				"$id":"#/definitions/common/text",
 				"title":"Text",
 				"type":"string",
-				"pattern":"^.*$"
+				"pattern":".*"
 			},
 			"positive_number":{
 				"$id":"#/definitions/common/positive_number",
@@ -130,36 +130,31 @@
 				"type":"string",
 				"pattern":"^.*$"
 			  },
-			  "text":{
-				"title":"Value",
-				"type":"string",
-				"pattern":"^.*$"
-			  },
-			  "full_url": {
-				  "title":"Url",
-				  "type":"string",
-				  "pattern": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
-			  },
-			  "var_change_policy": {
+		  "full_url": {
+			  "title":"Url",
+			  "type":"string",
+			  "pattern": "https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*)"
+		  },
+		  "var_change_policy": {
 				"type":"string",
 				"default": "each_iteration",
 				"enum": ["each_use", "each_request", "each_page", "each_iteration", "each_user"]
-			  },
-			  "var_scope": {
+		  },
+		  "var_scope": {
 				"type":"string",
 				"default": "global",
 				"enum": ["local", "global", "unique"]
-			  },
-			  "var_order": {
+		  },
+		  "var_order": {
 				"type":"string",
 				"default": "global",
 				"enum": ["sequential", "random", "any"]
-			  },
-			  "var_out_of_value": {
+		  },
+		  "var_out_of_value": {
 				"type":"string",
 				"default": "global",
 				"enum": ["cycle", "stop_test", "no_value_code"]
-			  }
+		  }
 		},
 		"variables": {
 			"generic": {
@@ -594,7 +589,17 @@
 						},
 						"headers": {
 							"type": "array",
-							"items": { "$ref": "#/definitions/common/text" }
+							"items": {
+		            "type": "object",
+		            "properties": {
+		              "name": {
+		                "type": "string"
+		              },
+		              "value": {
+		                "type": "string"
+		              }
+		            }
+		          }
 						},
 						"sla_profile": { "$ref": "#/definitions/common/text" },
 						"body": { "$ref": "#/definitions/common/text" },


### PR DESCRIPTION
## What?
Fix validate command to automatically pull from neoload-models the latest schema; also update this repo's version of the schema for reference docs.

## Why?
During as-code training prep, it was clear that our schema wasn't validating multi-line text such as request body properly.

## How?
Update schema in this repo and also make a PR to neoload-models for rapid turnaround: https://github.com/Neotys-Labs/neoload-models/pull/26

Update validation functionality to pull this if not cached locally, and also verify cached version against remote if possible.

## Testing
No additional testing required, schema acquisition process changed, not usage or outcomes. Training examples with multi-line bodies now validated successfully.