### PR TITLE
Update fastfail and SLA report, warning are not failures

### DIFF
--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -101,10 +101,10 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
                 failed_global = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_global']))
                 failed_test = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_test']))
                 failed_interval = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_interval']))
-                displayer.__print_sla(failed_global, datas['sla_test'], datas['sla_interval'])
+                displayer.__print_sla(failed_global, failed_test, failed_interval)
             else:
                 printif(sys.stdin.isatty() and not has_exited, '.', end = '')
-                
+
             time.sleep(15)
 
         dt_current = datetime.now()

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -56,7 +56,7 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
     has_exited = False
     msg = ""
     exit_code = 0
-    while (abs(dt_current-dt_started).seconds / 60) < 10:
+    while (abs(dt_current-dt_started).seconds / 60) < (60 * 4): # worst case scenario 4hrs
         datas = test_results.get_sla_data_by_name_or_id(__id)
 
         partial_intervals = list(filter(lambda x: x['status']=='FAILED',datas['sla_interval']))
@@ -88,13 +88,12 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
         is_running = outcomes["is_running"]
         exit_code = 0 if datas['result']['qualityStatus']=="PASSED" else 1
 
-        debugmsg = ""
-        if exit_code!=0:
-            debugmsg = "fastfail[results]: exit_code={} is a result of datas: {}".format(exit_code,yaml.dump(datas))
-            logging.debug(debugmsg)
-            msg += debugmsg
-
         if final_run:
+            debugmsg = ""
+            if exit_code!=0:
+                debugmsg = "fastfail[results]: exit_code={} is a result of datas: {}".format(exit_code,yaml.dump(datas))
+                logging.debug(debugmsg)
+                msg += debugmsg
             break
         elif (len(fails) > 0 or len(partial_intervals) > 0):
             displayer.__print_sla(datas['sla_global'], datas['sla_test'], datas['sla_interval'])

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -98,9 +98,9 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
             break
         else:
             if (len(fails) > 0 or len(partial_intervals) > 0):
-                failed_global = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_global']))
-                failed_test = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_test']))
-                failed_interval = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_interval']))
+                failed_global = list(filter(lambda x: 'status' in x and x['status'] == 'FAILED', datas['sla_global']))
+                failed_test = list(filter(lambda x: 'status' in x and x['status'] == 'FAILED', datas['sla_test']))
+                failed_interval = list(filter(lambda x: 'status' in x and x['status'] == 'FAILED', datas['sla_interval']))
                 displayer.__print_sla(failed_global, failed_test, failed_interval)
             else:
                 printif(sys.stdin.isatty() and not has_exited, '.', end = '')

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -56,7 +56,8 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
     has_exited = False
     msg = ""
     exit_code = 0
-    while (abs(dt_current-dt_started).seconds / 60) < (60 * 4): # worst case scenario 4hrs
+    mins_worst_case = get_duration_mins_by_result(__id)
+    while (abs(dt_current-dt_started).seconds / 60) < (60 * 4):
         datas = test_results.get_sla_data_by_name_or_id(__id)
 
         partial_intervals = list(filter(lambda x: x['status']=='FAILED',datas['sla_interval']))
@@ -110,6 +111,15 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
     print('fastfail ended: ' + str(dt_current))
 
     tools.system_exit({'message': msg, 'code': exit_code})
+
+def get_duration_mins_by_result(__id):
+
+    ret = (60 * 4) # initial default, if results -> settings -> project
+    #summary = test_results.get_json_summary(__id)["summary"]
+    #if 'testId' in summary
+
+    #rest_crud.get_from_file_storage(get_endpoint(setting_id))
+    return ret
 
 def process_state(datas,fails,fail_options,is_initializing,is_running):
 

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -96,10 +96,15 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
                 logging.debug(debugmsg)
                 msg += debugmsg
             break
-        elif (len(fails) > 0 or len(partial_intervals) > 0):
-            displayer.__print_sla(datas['sla_global'], datas['sla_test'], datas['sla_interval'])
         else:
-            printif(sys.stdin.isatty() and not has_exited, '.', end = '')
+            if (len(fails) > 0 or len(partial_intervals) > 0):
+                failed_global = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_global']))
+                failed_test = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_test']))
+                failed_interval = list(filter(lambda x: 'status' in x and x['status'] != 'PASSED', datas['sla_interval']))
+                displayer.__print_sla(failed_global, datas['sla_test'], datas['sla_interval'])
+            else:
+                printif(sys.stdin.isatty() and not has_exited, '.', end = '')
+                
             time.sleep(15)
 
         dt_current = datetime.now()

--- a/neoload/commands/fastfail.py
+++ b/neoload/commands/fastfail.py
@@ -6,6 +6,8 @@ from datetime import datetime, date
 import time
 import sys
 import subprocess
+import yaml
+import logging
 
 @click.command()
 @click.argument('command', type=click.Choice(['slas'], case_sensitive=False))
@@ -85,6 +87,12 @@ def monitor_loop(__id, stop, force, max_failure, stop_command):
         is_initializing = outcomes["is_initializing"]
         is_running = outcomes["is_running"]
         exit_code = 0 if datas['result']['qualityStatus']=="PASSED" else 1
+
+        debugmsg = ""
+        if exit_code!=0:
+            debugmsg = "fastfail[results]: exit_code={} is a result of datas: {}".format(exit_code,yaml.dump(datas))
+            logging.debug(debugmsg)
+            msg += debugmsg
 
         if final_run:
             break

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -130,6 +130,10 @@ def get_id_by_name_or_id(name):
 
     return __id
 
+def get_json_summary(__id):
+    return {
+        "summary": rest_crud.get(get_end_point(__id))
+    }
 
 def get_sla_data_by_name_or_id(name):
     __id = get_id_by_name_or_id(name)

--- a/neoload/neoload_cli_lib/displayer.py
+++ b/neoload/neoload_cli_lib/displayer.py
@@ -87,7 +87,7 @@ def __build_test_suite(json_result, kind, sla_json):
     test_name = sla_json['kpi']
 
     tc = TestCase(test_name, suite_name)
-    if status == "FAILED" or status == "WARNING":
+    if status == "FAILED": # or status == "WARNING":
         txt = __build_unit_test(json_result, kind, sla_json)
         tc.add_failure_info("SLA failed", txt, 'NeoLoad SLA')
 
@@ -137,6 +137,8 @@ def __build_unit_test(json_result, kind, sla_json):
     text += 'Results: <br/><br/>'
     text += '%s=%s%%<br/><br/>' % (sla_json['kpi'], str(reported))
     text += 'Created N/A<br/>'
+
+    text = text.replace('<br/>','\n')
 
     return text
 


### PR DESCRIPTION
## What?
Update fastfail logic so that it does not print all SLAs every 15s loop iteration. Also update SLA report output to not treat warnings on SLAs as test suite failures.

## Why?
When using fastfail, WFM was experiencing superfluous console output (fastfail prints) and in pipelines were blocked when SLA warnings were being interpreted as failures.

## How?
Update fastfail loop logic and displayer logic for junit output.

## Testing
All tests passed locally, no need to write an extra test for SLA outputs.