### PR TITLE
Sonar updates

### DIFF
--- a/neoload/commands/workspaces.py
+++ b/neoload/commands/workspaces.py
@@ -30,9 +30,9 @@ def cli(command, name_or_id):
     # avoid to make two requests if we have not id.
     if command == "ls":
         # The endpoint GET /workspaces/{workspaceId} is not yet implemented
-        filter = None
-        if name_or_id is not None: filter = "id={}".format(name_or_id)
-        tools.ls(None, True, __resolver, filter)
+        ws_filter = None
+        if name_or_id is not None: ws_filter = "id={}".format(name_or_id)
+        tools.ls(None, True, __resolver, ws_filter)
         return
 
     __id = tools.get_id(name_or_id, __resolver, is_id)

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,5 @@ markers =
     workspaces: marks tests of the "workspaces" sub-commands
     report: marks tests of the "report" sub-commands
     makelivecalls: marks test as using live calls to real API (not monkeypatch)
+    fastfail: marks tests of the "fastfail" sub-command
+    zones: marks tests of the "zones" sub-command

--- a/tests/commands/fastfail/test_fastfail_slas.py
+++ b/tests/commands/fastfail/test_fastfail_slas.py
@@ -12,6 +12,31 @@ from helpers.test_utils import *
 @pytest.mark.makelivecalls
 @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
 class TestFastfailSlas:
+    def test_fastfail_invalid_no_parameters(self):
+        runner = CliRunner()
+        result = runner.invoke(fastfail)
+        assert result.exit_code==2
+        assert 'Missing argument' in result.output
+
+    def test_fastfail_invalid_max_low(self):
+        runner = CliRunner()
+        result = runner.invoke(fastfail, ['--max-failure=-1','slas'])
+        assert result.exit_code==2
+        assert 'percentage tolerance must be between 0 and 100' in result.output
+
+    def test_fastfail_invalid_max_high(self):
+        runner = CliRunner()
+        result = runner.invoke(fastfail, ['--max-failure=125','slas'])
+        assert result.exit_code==2
+        assert 'percentage tolerance must be between 0 and 100' in result.output
+
+    def test_fastfail_invalid_bad_name(self):
+        runner = CliRunner()
+        invalid_name = 'this_is_an_invalid_test_result_name'
+        result = runner.invoke(fastfail, ['--max-failure=25','slas',invalid_name])
+        assert result.exit_code==1
+        assert "No id associated to the name '{}'".format(invalid_name) in result.output
+
     def test_fastfail_on_completed_test_raw(self):
         runner = CliRunner()
         result = runner.invoke(results, ['use','raw'])

--- a/tests/commands/fastfail/test_fastfail_slas.py
+++ b/tests/commands/fastfail/test_fastfail_slas.py
@@ -1,0 +1,21 @@
+import pytest
+import os
+from click.testing import CliRunner
+from commands.login import cli as login
+from commands.status import cli as status
+from commands.test_results import cli as results
+from commands.fastfail import cli as fastfail
+from helpers.test_utils import *
+
+@pytest.mark.fastfail
+@pytest.mark.slow
+@pytest.mark.makelivecalls
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestFastfailSlas:
+    def test_fastfail_on_completed_test_raw(self):
+        runner = CliRunner()
+        result = runner.invoke(results, ['use','raw'])
+        assert_success(result)
+        result = runner.invoke(fastfail, ['--max-failure','25','slas'])
+        assert result.exit_code==1
+        assert 'fastfail ended:' in result.output

--- a/tests/commands/zones/test_zones.py
+++ b/tests/commands/zones/test_zones.py
@@ -1,0 +1,50 @@
+import pytest
+from click.testing import CliRunner
+from commands.zones import cli as zones
+from helpers.test_utils import *
+
+
+@pytest.mark.zones
+@pytest.mark.makelivecalls
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestZones:
+    def test_list_all(self, monkeypatch):
+        runner = CliRunner()
+        # mock_api_get_with_pagination(monkeypatch, 'v3/resources/zones',
+        #              '[{"id": "defaultzone","name": "Default zone","type": "STATIC","controllers": [],"loadgenerators": []}]')
+        result = runner.invoke(zones)
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert len(json_result) > 1, "Was expecting more than one zone in the target environment"
+
+    def test_list_one(self, monkeypatch):
+        runner = CliRunner()
+        # mock_api_get_with_pagination(monkeypatch, 'v3/resources/zones',
+        #              '[{"id": "defaultzone","name": "Default zone","type": "STATIC","controllers": [],"loadgenerators": []}]')
+        result = runner.invoke(zones,['defaultzone'])
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert len(json_result) == 1, "Was expecting only one zone to come back from a single named zone listing"
+        assert json_result[0]['id'] == 'defaultzone'
+
+    def test_list_static(self, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(zones,['--static'])
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert len(json_result) > 0, "Was expecting at least one STATIC zone in the target environment"
+
+    def test_list_dynamic(self, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(zones,['--dynamic'])
+        assert_success(result)
+        json_result = json.loads(result.output)
+        assert len(json_result) > 0, "Was expecting at least one DYNATIC zone in the target environment"
+
+    def test_list_human(self, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(zones,['-h'])
+        assert_success(result)
+        assert 'TYPE	ID	NAME' in result.output, "Did not find column names in human-friendly output"
+        assert 'Controllers (' in result.output, "Did not find any zones with controller count information"
+        assert 'Load Generator (' in result.output, "Did not find any zones with load generator count information"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import sys
 
 sys.path.append('neoload')
 __default_random_token = '12345678912345678901ae6d8af6abcdefabcdefabcdef'
-__default_api_url = 'https://preprod-neoload-api.saas.neotys.com/'
+__default_api_url = 'https://neoload-web-api.neotys.perfreleng.org/'
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## What?
Resolve code smell, complexity in fastfail (refactored the loop) and increased pytest coverage in fastfail and zone commands.

## Why?
Because we like to make Sonar happy.

## How?
Refactored fastafil loop, renamed filter to non-builtin name on workspaces, and wrote fastfail and zone tests.

## Testing
See new fastfail and zone tests