### PR TITLE
Add docker coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,28 +9,43 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.6', '3.8']
-
+    env:
+      zoneId: xWbV4
+      image_ctrl: "public.ecr.aws/neotys/neoload-controller:7.7.0"
+      image_lg: "public.ecr.aws/neotys/neoload-loadgenerator:7.7.0"
+      merge_to_trunk: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Pre-cache Docker Images
+      run: |
+        docker pull ${{ env.image_ctrl }}
+        docker pull ${{ env.image_lg }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install .
         python -m pip install coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Test with pytest
+    - name: Test with pytest (unit / mocks)
       run: |
         PYTHONPATH="neoload" COVERAGE_FILE=.coverage.unit coverage3 run -m pytest
+    - name: Test with pytest (live calls / integration)
+      if: ${{ env.merge_to_trunk || github.event_name == 'pull_request' }}
+      run: |
+        neoload config set docker.controller.image=${{ env.image_ctrl }}
+        neoload config set docker.lg.image=${{ env.image_lg }}
+        neoload config set docker.zone=${{ env.zoneId }}
         PYTHONPATH="neoload" COVERAGE_FILE=.coverage.live coverage3 run -m pytest -v -x -m "makelivecalls" --makelivecalls --token ${{ secrets.NLWEB_TOKEN }} --url ${{ secrets.NLWEB_API_URL }} --workspace CLI
+    - name: Combine and Create Coverage Report
+      run: |
         coverage3 combine
         coverage3 xml
     - name: SonarCloud Scan

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,7 @@ jobs:
       image_ctrl: "public.ecr.aws/neotys/neoload-controller:7.7.0"
       image_lg: "public.ecr.aws/neotys/neoload-loadgenerator:7.7.0"
       merge_to_trunk: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      integration_moment: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -25,6 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Pre-cache Docker Images
+      if: ${{ env.merge_to_trunk || env.integration_moment }}
       run: |
         docker pull ${{ env.image_ctrl }}
         docker pull ${{ env.image_lg }}
@@ -38,7 +40,7 @@ jobs:
       run: |
         PYTHONPATH="neoload" COVERAGE_FILE=.coverage.unit coverage3 run -m pytest
     - name: Test with pytest (live calls / integration)
-      if: ${{ env.merge_to_trunk || github.event_name == 'pull_request' }}
+      if: ${{ env.merge_to_trunk || env.integration_moment }}
       run: |
         neoload config set docker.controller.image=${{ env.image_ctrl }}
         neoload config set docker.lg.image=${{ env.image_lg }}

--- a/neoload/neoload_cli_lib/docker_lib.py
+++ b/neoload/neoload_cli_lib/docker_lib.py
@@ -189,7 +189,7 @@ def extract_number(prefix, element):
 
 def max_number(prefix):
     containers_list = client.containers.list(all=True)
-    return max(map(lambda c: extract_number(prefix, c), containers_list))
+    return 0 if len(containers_list)==0 else max(map(lambda c: extract_number(prefix, c), containers_list))
 
 
 def start_container(image, configuration, count, reason):

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,3 +13,4 @@ markers =
     makelivecalls: marks test as using live calls to real API (not monkeypatch)
     fastfail: marks tests of the "fastfail" sub-command
     zones: marks tests of the "zones" sub-command
+    docker: marks tests of the "docker" sub-command

--- a/tests/commands/docker/test_docker_cleanups.py
+++ b/tests/commands/docker/test_docker_cleanups.py
@@ -1,0 +1,24 @@
+import pytest
+import os
+from click.testing import CliRunner
+from commands.login import cli as login
+from commands.status import cli as status
+from commands.docker import cli as docker
+from neoload_cli_lib import docker_lib
+from helpers.test_utils import *
+import json
+import tempfile
+
+@pytest.mark.docker
+@pytest.mark.slow
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestDockerCleanups:
+    def test_docker_clean(self):
+        runner = CliRunner()
+        result = runner.invoke(docker, ['clean'])
+        assert_success(result)
+
+    def test_docker_forget(self):
+        runner = CliRunner()
+        result = runner.invoke(docker, ['forget'])
+        assert_success(result)

--- a/tests/commands/docker/test_docker_connections.py
+++ b/tests/commands/docker/test_docker_connections.py
@@ -1,0 +1,45 @@
+import pytest
+import os
+from click.testing import CliRunner
+from commands.login import cli as login
+from commands.status import cli as status
+from commands.docker import cli as docker
+from neoload_cli_lib import docker_lib
+from helpers.test_utils import *
+import json
+import tempfile
+
+@pytest.mark.docker
+@pytest.mark.slow
+@pytest.mark.makelivecalls
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestDockerConnections:
+    def test_docker_status(self):
+        runner = CliRunner()
+        result = runner.invoke(docker, ['status'])
+        assert_success(result)
+        assert docker_lib.DOCKER_CONTROLLER_IMAGE in result.output, "Could not find indicators of successful connection to Docker environment"
+
+    def test_docker_up_and_down(self):
+        runner = CliRunner()
+        last_err = None
+        up_happened = False
+        down_happened = False
+        try:
+            result = runner.invoke(docker, ['up'])
+            assert_success(result)
+            up_happened = True
+        except Exception as err:
+            last_err = err
+
+        try:
+            # always try, even if for simply to clean up
+            result = runner.invoke(docker, ['down'])
+            if up_happened:
+                assert_success(result)
+                down_happened = True
+        except:
+            last_err = err
+
+        assert up_happened, "Could not run the docker UP command: {}".format("" if last_err is None else str(last_err))
+        assert down_happened, "Could not run the docker DOWN command: {}".format("" if last_err is None else str(last_err))

--- a/tests/commands/docker/test_docker_hooks.py
+++ b/tests/commands/docker/test_docker_hooks.py
@@ -1,0 +1,30 @@
+import pytest
+import os
+from click.testing import CliRunner
+from commands.login import cli as login
+from commands.status import cli as status
+from commands.docker import cli as docker
+from neoload_cli_lib import docker_lib
+from helpers.test_utils import *
+import json
+import tempfile
+
+@pytest.mark.docker
+@pytest.mark.slow
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestDockerHooks:
+    def test_docker_install(self):
+        runner = CliRunner()
+        result = runner.invoke(docker, ['install'])
+        assert_success(result)
+        result = runner.invoke(docker, ['status'])
+        assert_success(result)
+        assert 'docker hooks is installed', "Could not verify that docker hooks is installed"
+
+    def test_docker_uninstall(self):
+        runner = CliRunner()
+        result = runner.invoke(docker, ['uninstall'])
+        assert_success(result)
+        result = runner.invoke(docker, ['status'])
+        assert_success(result)
+        assert 'docker hooks is not installed', "Could not verify that docker hooks is uninstalled"


### PR DESCRIPTION
## What?
Add pytests for Docker and the execution dependencies in Github Actions package workflow to accommodate them.

## Why?
Because without these tests, our Sonar coverage is undermined, not to mention that functionality shipped, even if experimental should have at least basic automated test coverage.

## How?
It turns out that Docker is already installed and ready to use on Ubuntu Github build hosts, so simply setting some context between the unit test run and the integration test run allows our Docker functionality to work right out of the box. Additionally, the images used are ECR 7.7.0 based to reduce the likelihood of Dockerhub rate limiting. Also, this should only run when A) pushing to master, or B) creating a PR.

## Testing
Added a few test files to cover main use cases and commands. Works both locally (Mac) and in Github Actions workflow (Ubuntu) with Docker and Python installed.