### PR TITLE
Make status human readable

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ name: Python package
 on:
   push:
     branches: [ '**' ]
+  pull_request:
+    branches:
+      - master
 
 jobs:
   diffs:

--- a/neoload/neoload_cli_lib/name_resolver.py
+++ b/neoload/neoload_cli_lib/name_resolver.py
@@ -1,5 +1,4 @@
-import neoload_cli_lib.rest_crud as rest_crud
-from neoload_cli_lib import cli_exception
+from neoload_cli_lib import rest_crud,cli_exception
 
 
 class Resolver:

--- a/tests/commands/status/test_status_with_names.py
+++ b/tests/commands/status/test_status_with_names.py
@@ -1,0 +1,33 @@
+import time
+from urllib.parse import quote
+
+import pytest
+from click.testing import CliRunner
+from commands.login import cli as login
+from commands.logout import cli as logout
+from commands.status import cli as status
+from commands.test_settings import cli as settings
+from commands.workspaces import cli as workspaces
+from commands.test_results import cli as results
+
+from helpers.test_utils import *
+
+
+@pytest.mark.makelivecalls
+@pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+class TestStatusWithNames:
+    def test_status_with_name_resolution(self, monkeypatch):
+        runner = CliRunner()
+
+        results_use = runner.invoke(results, ['use','raw'])
+        assert_success(results_use)
+
+        settings_use = runner.invoke(settings, ['use','180938f4-5749-493c-a341-cbe48d9f1a57'])
+        assert_success(settings_use)
+
+        result_status2 = runner.invoke(status)
+        assert_success(result_status2)
+
+        assert 'workspace id: 5fcaeff6430f780001e3fb3e (CLI)' in result_status2.output
+        assert 'result id: 44f1a611-bad3-451f-a7d5-9534cf62ee26 (raw)' in result_status2.output
+        assert 'settings id: 180938f4-5749-493c-a341-cbe48d9f1a57 (For Unit Tests Report Command (Do not remove))' in result_status2.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from _pytest.main import Session
 from click.testing import CliRunner
 from commands.login import cli as login
 from commands.status import cli as status
+from commands.config import cli as config
 from helpers.test_utils import mock_login_get_urls
 
 import sys
@@ -32,6 +33,7 @@ def pytest_sessionstart(session: Session):
     The test suite needs to start already logged in, because during the class initialization
     of the commands, the function base_endpoint_with_workspace() throw an exception if not logged in.
     """
+    CliRunner().invoke(config, ["set", "status.resolvenames=False"])
     CliRunner().invoke(login, ["xxxxx", '--url', "bad_url"])
 
 
@@ -40,6 +42,12 @@ def neoload_login(request, monkeypatch):
     token = request.config.getoption('--token')
     api_url = request.config.getoption('--url')
     workspace = request.config.getoption('--workspace')
+
+    makelivecalls = request.config.getoption('--makelivecalls')
+    if makelivecalls:
+        CliRunner().invoke(config, ["set", "status.resolvenames=True"])
+        CliRunner().invoke(config, ["set", "docker.zone=xWbV4"])
+
     runner = CliRunner()
     result_status = runner.invoke(status)
     # do login if not already logged-in with the right credentials


### PR DESCRIPTION
## What?
Add id-->name resolution to 'status' subcommand and related test(s).

## Why?
Humans need quick verification that the workspace/test-settings/test-results currently selected are the ones they can relate to in the GUI (via human-readable names, not just long IDs).

## How?
Add custom readable name resolver that uses associated endpoints to look up and resolve the readable name given ids.

## Testing
Added @makelivecalls integration test tests/commands/status/test_status_with_names.py

## Additional Notes
Updated UserData class with a custom function to resolve these three entity types and only run when --makelivecalls is used in pytest, pre-configuring the CLI with a custom key 'status.resolvenames' that causes normal pytest suite not to resolve names against live calls unless specifically directed by the --makelivecalls option.