### PR TITLE
Update changelog

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,10 @@ jobs:
             if [[ $file == *docker* ]]; then
               echo "::set-output name=found_one::true"
             fi
-            if [[ $file == */workflows/*.yml ]]; then
+            if [[ $file == */workflows/*package*yml ]]; then
+              echo "::set-output name=workflow_change::true"
+            fi
+            if [[ $file == */workflows/*integration*yml ]]; then
               echo "::set-output name=workflow_change::true"
             fi
           done < diff_files.txt

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,6 +20,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - name: Update Changelog for Dist
+      run: |
+        github_changelog_generator -u Neotys-Labs -p neoload-cli --token ${{ secrets.GIT_CHANGELOG_GEN }} --exclude-tags-regex ".*(dev|rc).*" --add-sections '{"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}'
+        cat CHANGELOG.md
     - name: Build package
       run: |
         python setup.py sdist bdist_wheel
@@ -28,3 +32,10 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_TOKEN }}
+    - name: Archive Changelog
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: CHANGELOG
+        path: CHANGELOG.md
+        retention-days: 5

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -20,8 +20,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
     - name: Update Changelog for Dist
       run: |
+        gem install github_changelog_generator
         github_changelog_generator -u Neotys-Labs -p neoload-cli --token ${{ secrets.GIT_CHANGELOG_GEN }} --exclude-tags-regex ".*(dev|rc).*" --add-sections '{"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}'
         cat CHANGELOG.md
     - name: Build package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,199 @@
 # Changelog
 
-## 1.1.8 (2020-12-04)
-- [Fix] removed pyparsing dep altogether; unnecessary
+## [1.3.0](https://github.com/Neotys-Labs/neoload-cli/tree/1.3.0) (2021-03-18)
 
-## 1.1.7 (2020-12-04)
-- [Fix] add retry logic to HTTP requesting
-- [Fix] add pyparsing dependency for Jenkins pipelines
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.2.1...1.3.0)
 
-## 1.1.6 (2020-12-03)
-- [Fix] remove useless dependency
+**Implemented enhancements:**
 
-## 1.1.5 (2020-11-25)
-- [Feature] Filtering for ls-related commands
-- [Feature] Progress bar at project upload
-- [Feature] Add Bamboo pipeline example
-- [Fix] Global SLA are not displayed in Junit report
+- Add Docker command [\#124](https://github.com/Neotys-Labs/neoload-cli/pull/124) ([neotys-rd](https://github.com/neotys-rd))
 
-## 1.1.4 (2020-09-25)
-- [Feature] Capability to manage self signed certificate
-- [Feature] .nlignore files allow you to specify yaml files not to upload (ex: .gitlab-ci.yaml)
-- [Feature] Add AWS pipeline example
-- [Feature] Add 'cur' pseudonym support to logs-url command
+**Closed issues:**
 
-## 1.1.0 (2020-08-11)
-- [Feature] Workspace command and support workspaces at login
-- [Feature] Fastfail command and the jenkins example for fastfail
-- [Improvement] Jenkins pipeline example and many other small improvements
-- [Improvement] Better error message for bad NL url
-- [Fix] Handling of pagination by API for ls subcommand
-- [Fix] Support "between" threshold in SLA</li></ul>
+- Issue project upload on current directory [\#125](https://github.com/Neotys-Labs/neoload-cli/issues/125)
 
-## 1.0.1 (2020-06-25)
-- [Fix] Set required versions for setup
-- [Fix] error when displaying results at the end of the test
+**Merged pull requests:**
 
-## 1.0.0 (2020-05-14)
-Initial version with commands and sub-commands
+- Revert "Explain which file is empty" [\#136](https://github.com/Neotys-Labs/neoload-cli/pull/136) ([stephanemartin](https://github.com/stephanemartin))
+- Fix test [\#135](https://github.com/Neotys-Labs/neoload-cli/pull/135) ([stephanemartin](https://github.com/stephanemartin))
+- Explain which file is empty [\#134](https://github.com/Neotys-Labs/neoload-cli/pull/134) ([stephanemartin](https://github.com/stephanemartin))
+- Add QA scripts to test the CLI on a real NLW [\#131](https://github.com/Neotys-Labs/neoload-cli/pull/131) ([guillaumebert](https://github.com/guillaumebert))
+- Add manual pipeline for integration tests [\#130](https://github.com/Neotys-Labs/neoload-cli/pull/130) ([guillaumebert](https://github.com/guillaumebert))
 
-## 0.4.6 (2020-05-09)
-Experimental version
+## [1.2.1](https://github.com/Neotys-Labs/neoload-cli/tree/1.2.1) (2021-03-01)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.2.0...1.2.1)
+
+**Implemented enhancements:**
+
+- Auto refresh schema if possible; allow whole directory validation [\#127](https://github.com/Neotys-Labs/neoload-cli/pull/127) ([paulsbruce](https://github.com/paulsbruce))
+
+**Fixed bugs:**
+
+- Fixbug \#125 currend directory issue on neoload project upload. [\#126](https://github.com/Neotys-Labs/neoload-cli/pull/126) ([neotys-rd](https://github.com/neotys-rd))
+
+**Merged pull requests:**
+
+- Set command for report command user agent [\#129](https://github.com/Neotys-Labs/neoload-cli/pull/129) ([guillaumebert](https://github.com/guillaumebert))
+
+## [1.2.0](https://github.com/Neotys-Labs/neoload-cli/tree/1.2.0) (2021-02-18)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.2.0rc1...1.2.0)
+
+**Implemented enhancements:**
+
+- Add custom command support to fastfail [\#122](https://github.com/Neotys-Labs/neoload-cli/pull/122) ([paulsbruce](https://github.com/paulsbruce))
+- Add --save path argument to upload command [\#117](https://github.com/Neotys-Labs/neoload-cli/pull/117) ([paulsbruce](https://github.com/paulsbruce))
+- Add global config feature [\#115](https://github.com/Neotys-Labs/neoload-cli/pull/115) ([stephanemartin](https://github.com/stephanemartin))
+- Topic report command [\#107](https://github.com/Neotys-Labs/neoload-cli/pull/107) ([paulsbruce](https://github.com/paulsbruce))
+
+**Merged pull requests:**
+
+- Add interactive or automated information to UserAgent header [\#123](https://github.com/Neotys-Labs/neoload-cli/pull/123) ([guillaumebert](https://github.com/guillaumebert))
+- Fix user agent header value when chaining commands [\#121](https://github.com/Neotys-Labs/neoload-cli/pull/121) ([guillaumebert](https://github.com/guillaumebert))
+- Improve unit testing - createorpatch command [\#120](https://github.com/Neotys-Labs/neoload-cli/pull/120) ([guillaumebert](https://github.com/guillaumebert))
+- Compute version in tools.py to make it available to other commands [\#119](https://github.com/Neotys-Labs/neoload-cli/pull/119) ([guillaumebert](https://github.com/guillaumebert))
+- Fix typo in error message when not logged in. [\#118](https://github.com/Neotys-Labs/neoload-cli/pull/118) ([guillaumebert](https://github.com/guillaumebert))
+
+## [1.1.8](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.8) (2020-12-04)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.7...1.1.8)
+
+**Merged pull requests:**
+
+- Remove pyparsing dependency [\#113](https://github.com/Neotys-Labs/neoload-cli/pull/113) ([paulsbruce](https://github.com/paulsbruce))
+
+## [1.1.7](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.7) (2020-12-04)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.6...1.1.7)
+
+**Implemented enhancements:**
+
+- Retry after the specified delay when NLW rate limit is reached [\#111](https://github.com/Neotys-Labs/neoload-cli/pull/111) ([guillaumebert](https://github.com/guillaumebert))
+
+**Merged pull requests:**
+
+- Add 'pyparsing' to setup dependencies, tested/working in Jenkinsfile\_… [\#112](https://github.com/Neotys-Labs/neoload-cli/pull/112) ([paulsbruce](https://github.com/paulsbruce))
+- Add github actions for package and release on pypi [\#108](https://github.com/Neotys-Labs/neoload-cli/pull/108) ([guillaumebert](https://github.com/guillaumebert))
+
+## [1.1.6](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.6) (2020-12-03)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.5...1.1.6)
+
+**Implemented enhancements:**
+
+- Add 'cur' pseudonym support to logs-url [\#98](https://github.com/Neotys-Labs/neoload-cli/pull/98) ([stephanemartin](https://github.com/stephanemartin))
+
+**Documentation updates:**
+
+- Update CHANGELOG.md [\#110](https://github.com/Neotys-Labs/neoload-cli/pull/110) ([stephanemartin](https://github.com/stephanemartin))
+- Create default PR template [\#106](https://github.com/Neotys-Labs/neoload-cli/pull/106) ([paulsbruce](https://github.com/paulsbruce))
+- Version management on pypi in readme [\#105](https://github.com/Neotys-Labs/neoload-cli/pull/105) ([guillaumebert](https://github.com/guillaumebert))
+
+**Closed issues:**
+
+- No Result Found to Publish : SLA Reporting via JUnit  [\#99](https://github.com/Neotys-Labs/neoload-cli/issues/99)
+
+**Merged pull requests:**
+
+- Define test requirements in a separate file [\#109](https://github.com/Neotys-Labs/neoload-cli/pull/109) ([guillaumebert](https://github.com/guillaumebert))
+
+## [1.1.5](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.5) (2020-11-10)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.4...1.1.5)
+
+**Implemented enhancements:**
+
+- Filtering for ls-related commands [\#102](https://github.com/Neotys-Labs/neoload-cli/pull/102) ([paulsbruce](https://github.com/paulsbruce))
+- Update largefile upload [\#91](https://github.com/Neotys-Labs/neoload-cli/pull/91) ([paulsbruce](https://github.com/paulsbruce))
+
+**Documentation updates:**
+
+- Review of documentation [\#103](https://github.com/Neotys-Labs/neoload-cli/pull/103) ([guillaumebert](https://github.com/guillaumebert))
+- Improve Readme [\#101](https://github.com/Neotys-Labs/neoload-cli/pull/101) ([guillaumebert](https://github.com/guillaumebert))
+- Add bamboo pipeline example [\#100](https://github.com/Neotys-Labs/neoload-cli/pull/100) ([guillaumebert](https://github.com/guillaumebert))
+
+**Closed issues:**
+
+- Error 500 with cli-python and dynamic Infrastructure \(Pipeline yaml Azure DevOps\) [\#95](https://github.com/Neotys-Labs/neoload-cli/issues/95)
+
+**Merged pull requests:**
+
+- Add global SLAs \(test\) [\#104](https://github.com/Neotys-Labs/neoload-cli/pull/104) ([ceimard-neo](https://github.com/ceimard-neo))
+
+## [1.1.4](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.4) (2020-09-25)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.4rc8...1.1.4)
+
+**Implemented enhancements:**
+
+- Add capability to manage self signed certificate [\#94](https://github.com/Neotys-Labs/neoload-cli/pull/94) ([stephanemartin](https://github.com/stephanemartin))
+- Update to use master branch and include --lgs [\#93](https://github.com/Neotys-Labs/neoload-cli/pull/93) ([paulsbruce](https://github.com/paulsbruce))
+
+**Fixed bugs:**
+
+- Remove timeout for bigfile and slow server [\#97](https://github.com/Neotys-Labs/neoload-cli/pull/97) ([stephanemartin](https://github.com/stephanemartin))
+
+## [1.1.3](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.3) (2020-08-19)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.2...1.1.3)
+
+## [1.1.2](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.2) (2020-08-18)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.1rc1...1.1.2)
+
+**Implemented enhancements:**
+
+- Topic upload .nlignore [\#90](https://github.com/Neotys-Labs/neoload-cli/pull/90) ([paulsbruce](https://github.com/paulsbruce))
+
+**Documentation updates:**
+
+- Add AWS CodeBuild example pipeline [\#84](https://github.com/Neotys-Labs/neoload-cli/pull/84) ([paulsbruce](https://github.com/paulsbruce))
+
+## [1.1.0](https://github.com/Neotys-Labs/neoload-cli/tree/1.1.0) (2020-08-11)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.0rc2...1.1.0)
+
+**Implemented enhancements:**
+
+- Topic pagination [\#89](https://github.com/Neotys-Labs/neoload-cli/pull/89) ([guillaumebert](https://github.com/guillaumebert))
+- Topic workspace compatibility [\#85](https://github.com/Neotys-Labs/neoload-cli/pull/85) ([guillaumebert](https://github.com/guillaumebert))
+- Topic fastfail command [\#73](https://github.com/Neotys-Labs/neoload-cli/pull/73) ([paulsbruce](https://github.com/paulsbruce))
+
+**Fixed bugs:**
+
+- Fix the bug : Run a test and specify the scenario [\#77](https://github.com/Neotys-Labs/neoload-cli/pull/77) ([guillaumebert](https://github.com/guillaumebert))
+
+**Documentation updates:**
+
+- Fix issue on sample Jenkinsfile [\#76](https://github.com/Neotys-Labs/neoload-cli/pull/76) ([stephanemartin](https://github.com/stephanemartin))
+- Add as-code schema to keep compatibility with CLI v0 [\#70](https://github.com/Neotys-Labs/neoload-cli/pull/70) ([guillaumebert](https://github.com/guillaumebert))
+
+**Merged pull requests:**
+
+- Miscellaneous improvements [\#86](https://github.com/Neotys-Labs/neoload-cli/pull/86) ([stephanemartin](https://github.com/stephanemartin))
+- Add 'certifi' install prerequisite [\#78](https://github.com/Neotys-Labs/neoload-cli/pull/78) ([paulsbruce](https://github.com/paulsbruce))
+
+## [1.0.1](https://github.com/Neotys-Labs/neoload-cli/tree/1.0.1) (2020-06-25)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.0rc1...1.0.1)
+
+**Fixed bugs:**
+
+- Fix issue \#74 [\#75](https://github.com/Neotys-Labs/neoload-cli/pull/75) ([stephanemartin](https://github.com/stephanemartin))
+
+**Closed issues:**
+
+- tests failing on master with python3.6 [\#65](https://github.com/Neotys-Labs/neoload-cli/issues/65)
+
+**Merged pull requests:**
+
+- update setup with minimum versions [\#71](https://github.com/Neotys-Labs/neoload-cli/pull/71) ([adamleskis](https://github.com/adamleskis))
+
+## [1.0.0](https://github.com/Neotys-Labs/neoload-cli/tree/1.0.0) (2020-05-14)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.0.0rc3...1.0.0)
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased](https://github.com/Neotys-Labs/neoload-cli/tree/HEAD)
+
+[Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.3.0...HEAD)
+
+**Fixed bugs:**
+
+- Update fastfail and SLA report, warning are not failures [\#145](https://github.com/Neotys-Labs/neoload-cli/pull/145) ([paulsbruce](https://github.com/paulsbruce))
+- Fix report 00184240 [\#143](https://github.com/Neotys-Labs/neoload-cli/pull/143) ([paulsbruce](https://github.com/paulsbruce))
+- Convert entity property values to string before filter compare [\#133](https://github.com/Neotys-Labs/neoload-cli/pull/133) ([paulsbruce](https://github.com/paulsbruce))
+- Fix trends back/ahead result selection logic [\#132](https://github.com/Neotys-Labs/neoload-cli/pull/132) ([paulsbruce](https://github.com/paulsbruce))
+
+**Documentation updates:**
+
+- fix\(doc\): Issues with gitlab openshit CI examples [\#141](https://github.com/Neotys-Labs/neoload-cli/pull/141) ([TanguyBaudrin](https://github.com/TanguyBaudrin))
+- Update changelog with auto-generated details; old one only went to 1.… [\#137](https://github.com/Neotys-Labs/neoload-cli/pull/137) ([paulsbruce](https://github.com/paulsbruce))
+
+**Merged pull requests:**
+
+- Fix validate command from as-code training outcomes [\#144](https://github.com/Neotys-Labs/neoload-cli/pull/144) ([paulsbruce](https://github.com/paulsbruce))
+- Update ls to use internal filtering b/c endpoint not implemented; tes… [\#142](https://github.com/Neotys-Labs/neoload-cli/pull/142) ([paulsbruce](https://github.com/paulsbruce))
+
 ## [1.3.0](https://github.com/Neotys-Labs/neoload-cli/tree/1.3.0) (2021-03-18)
 
 [Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.2.1...1.3.0)
@@ -80,10 +101,6 @@
 
 [Full Changelog](https://github.com/Neotys-Labs/neoload-cli/compare/1.1.5...1.1.6)
 
-**Implemented enhancements:**
-
-- Add 'cur' pseudonym support to logs-url [\#98](https://github.com/Neotys-Labs/neoload-cli/pull/98) ([stephanemartin](https://github.com/stephanemartin))
-
 **Documentation updates:**
 
 - Update CHANGELOG.md [\#110](https://github.com/Neotys-Labs/neoload-cli/pull/110) ([stephanemartin](https://github.com/stephanemartin))
@@ -127,6 +144,7 @@
 
 **Implemented enhancements:**
 
+- Add 'cur' pseudonym support to logs-url [\#98](https://github.com/Neotys-Labs/neoload-cli/pull/98) ([stephanemartin](https://github.com/stephanemartin))
 - Add capability to manage self signed certificate [\#94](https://github.com/Neotys-Labs/neoload-cli/pull/94) ([stephanemartin](https://github.com/stephanemartin))
 - Update to use master branch and include --lgs [\#93](https://github.com/Neotys-Labs/neoload-cli/pull/93) ([paulsbruce](https://github.com/paulsbruce))
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ docker.lg.default_count (default: 2).
 Usage: neoload docker [OPTIONS] [up|down|clean|forget|install|uninstall|status]
 
 
-neoload docker up / down         # start or delete container depend on configuration 
+neoload docker up / down         # start or delete container depend on configuration
 neoload docker install/uninstall # add/remove hooks on run command to up when the controller zone is same and zone is empty. Shut down at the end of test running.
 neoload docker forget            # remove container from the launched list. That avoid to be removed with down command.
 neoload docker clean             # remove all container created by neoload-cli even if it was forgotten.
@@ -433,6 +433,8 @@ Status of IDE / editor integrations
 ## Contributing
 Feel free to fork this repo, make changes, *test locally*, and create a pull request.
 
+### Local Verification
+
 #### Tests
 As part of your testing, you should run the built-in test suite with the following command: \
 NOTE: for testing from Mac, please change the PYTHONPATH separators below to colons (:) instead of semicolons (;).
@@ -450,6 +452,22 @@ Additionally, any contributions to the DSL validation functionality, such as on 
 ./tests/neoload_projects/yaml_variants/validate_all.sh
 ```
 This command executes a number of NEGATIVE tests to prove that changes to the JSON schema or validation process produce failures when their input is malformed in very specific ways (common mistakes).
+
+### Release Process (managed by Neotys team)
+
+#### Auto-generating Changelog
+
+Before tagging a release, merged PRs should update the CHANGELOG.md via the following:
+
+```
+github_changelog_generator -u Neotys-Labs -p neoload-cli --token $GIT_CHANGELOG_GEN --exclude-tags-regex ".*(dev|rc).*" --add-sections '{"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}'
+```
+
+This utility is a [Ruby-based GEM](https://github.com/github-changelog-generator/github-changelog-generator) that can be installed (also used in CI/Actions) as follows:
+
+```
+gem install github_changelog_generator
+```
 
 #### Version management on pypi
 Suppose X, Y, Z and N are integers, versions will be named as following on pypi: \


### PR DESCRIPTION
## What?
Add auto-gen CHANGELOG.md functionality to packaging process.

## Why?
After tag and just before packaging/uploading to PyPi, and auto-generated CHANGELOG should be created with latest info (label-based on PRs) and always provide up-to-date information on what's changed between versions.

## How?
Use ruby tool 'github_changelog_generator' with authenticated calls to Github API (reduce rate limiting).

## Testing
Tested extensively locally and discussed with Guillaume. Subsequently, this should also be used to push changes back to master branch after merges to master and testing is successful.

## Additional Notes
Old CHANGELOG was WAY out of date.