### PR TITLE
Split out CHANGELOG from tag release workflows

### DIFF
--- a/.github/workflows/python-post-release-changelog-pr.yml
+++ b/.github/workflows/python-post-release-changelog-pr.yml
@@ -1,0 +1,64 @@
+name: CHANGELOG PR After Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release Tag'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    #if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'dev') }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        ref: refs/tags/${{ github.event.inputs.tag }}
+    - name: Check Git Sources
+      run: |
+        git remote -v show
+        git branch
+        git tag --list
+        git status
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - name: Update Changelog for Dist
+      run: |
+        gem install github_changelog_generator
+        github_changelog_generator -u Neotys-Labs -p neoload-cli --token ${{ secrets.GIT_CHANGELOG_GEN }} --exclude-tags-regex ".*(dev|rc).*" --add-sections '{"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}'
+        cat CHANGELOG.md
+    - name: Re-check Git Sources
+      run: |
+        git remote -v show
+        git branch
+        git tag --list
+        git status
+    - name: "Push CHANGELOG to master"
+      run: |
+        TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/||g')
+        git checkout -b "Post-release $TAG CHANGELOG Update"
+        git remote -v show
+        git branch
+        git status
+
+        git add CHANGELOG.md
+        git status
+        git commit -m "Auto-gen CHANGELOG via Github Action after successful upload to Pypi"
+        git status
+        git log -n 5
+        git push
+    - name: pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "master"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Archive Changelog
+      uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: CHANGELOG
+        path: CHANGELOG.md
+        retention-days: 5

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -7,13 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      is_pre_release: ${{ contains(github.ref, 'rc') || contains(github.ref, 'dev') }}
     steps:
     - uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        ref: ${{ github.ref }}
     - name: Set up Python 3.x
       uses: actions/setup-python@v2
       with:
@@ -24,26 +19,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-    - name: Check Git Sources
-      run: |
-        git remote -v show
-        git branch
-        git tag --list
-        git status
-    # - name: Update Changelog for Dist
-    #   run: |
-    #     gem install github_changelog_generator
-    #     github_changelog_generator -u Neotys-Labs -p neoload-cli --token ${{ secrets.GIT_CHANGELOG_GEN }} --exclude-tags-regex ".*(dev|rc).*" --add-sections '{"documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}}'
-    #     cat CHANGELOG.md
-    # - name: Re-check Git Sources
-    #   run: |
-    #     git remote -v show
-    #     git branch
-    #     git tag --list
-    #     git status
     - name: Build package
       run: |
         python setup.py sdist bdist_wheel
@@ -52,19 +27,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_TOKEN }}
-    - name: "If-Full-Release: Push CHANGELOG to master"
-      if: ${{ contains(github.ref, 'refs/tags') && env.is_pre_release == 'false' }}
-      run: |
-        git remote -v show
-        git branch
-
-        git add CHANGELOG.md
-        git commit -m "Auto-gen CHANGELOG via Github Action after successful upload to Pypi"
-        git push
-    - name: Archive Changelog
-      uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: CHANGELOG
-        path: CHANGELOG.md
-        retention-days: 5


### PR DESCRIPTION
## What?
Create CHANGELOG update workflow as a separate dispatch event for after-tag-release moment.

## Why?
Tag has to be processed (released) and official before being combined into auto-gen CHANGELOG.

## How?
Create separate workflow, and simplify the release workflow back to original model.