### PR TITLE
Fix test mod refs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='neoload',
-    package_data={'': [
-        'LICENSE',
-        'README.md'
-    ]},
+    include_package_data=True,
     packages=find_packages(exclude=("tests",)),
     entry_points={
         'console_scripts': [

--- a/tests/commands/docker/test_docker_cleanups.py
+++ b/tests/commands/docker/test_docker_cleanups.py
@@ -5,7 +5,7 @@ from commands.login import cli as login
 from commands.status import cli as status
 from commands.docker import cli as docker
 from neoload_cli_lib import docker_lib
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 import json
 import tempfile
 

--- a/tests/commands/docker/test_docker_connections.py
+++ b/tests/commands/docker/test_docker_connections.py
@@ -5,7 +5,7 @@ from commands.login import cli as login
 from commands.status import cli as status
 from commands.docker import cli as docker
 from neoload_cli_lib import docker_lib
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 import json
 import tempfile
 

--- a/tests/commands/docker/test_docker_hooks.py
+++ b/tests/commands/docker/test_docker_hooks.py
@@ -5,7 +5,7 @@ from commands.login import cli as login
 from commands.status import cli as status
 from commands.docker import cli as docker
 from neoload_cli_lib import docker_lib
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 import json
 import tempfile
 

--- a/tests/commands/fastfail/test_fastfail_slas.py
+++ b/tests/commands/fastfail/test_fastfail_slas.py
@@ -5,7 +5,7 @@ from commands.login import cli as login
 from commands.status import cli as status
 from commands.test_results import cli as results
 from commands.fastfail import cli as fastfail
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 @pytest.mark.fastfail
 @pytest.mark.slow

--- a/tests/commands/project/test_upload.py
+++ b/tests/commands/project/test_upload.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.project import cli as project
 from commands.status import cli as status
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 from neoload_cli_lib import neoLoad_project
 import os, tempfile, time

--- a/tests/commands/report/test_report_json_output.py
+++ b/tests/commands/report/test_report_json_output.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from commands import report
 from commands.logout import cli as logout
 from commands.workspaces import cli as workspaces
-from helpers.test_utils import assert_success
+from tests.helpers.test_utils import assert_success
 from neoload_cli_lib import rest_crud
 from neoload_cli_lib.user_data import UserData
 

--- a/tests/commands/report/test_report_templates.py
+++ b/tests/commands/report/test_report_templates.py
@@ -4,7 +4,7 @@ import pytest
 from click.testing import CliRunner
 
 from commands.report import cli as report
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 from neoload_cli_lib import tools
 
 

--- a/tests/commands/report/test_report_transactions.py
+++ b/tests/commands/report/test_report_transactions.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from commands.login import cli as login
 from commands.test_results import cli as results
 from commands.report import cli as report
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 import tempfile
 
 @pytest.mark.report

--- a/tests/commands/report/test_report_trends.py
+++ b/tests/commands/report/test_report_trends.py
@@ -6,7 +6,7 @@ from commands.status import cli as status
 from commands.test_results import cli as results
 from commands.report import cli as report
 from commands.report import is_guid
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 import json
 import tempfile
 

--- a/tests/commands/report/test_trends_json_output.py
+++ b/tests/commands/report/test_trends_json_output.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 from commands import report
 from commands.logout import cli as logout
 from commands.workspaces import cli as workspaces
-from helpers.test_utils import assert_success
+from tests.helpers.test_utils import assert_success
 from neoload_cli_lib import rest_crud
 
 import os

--- a/tests/commands/report/test_trends_templates.py
+++ b/tests/commands/report/test_trends_templates.py
@@ -4,7 +4,7 @@ import pytest
 from click.testing import CliRunner
 
 from commands.report import cli as report
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 from neoload_cli_lib import tools
 
 

--- a/tests/commands/status/test_status_with_names.py
+++ b/tests/commands/status/test_status_with_names.py
@@ -10,7 +10,7 @@ from commands.test_settings import cli as settings
 from commands.workspaces import cli as workspaces
 from commands.test_results import cli as results
 
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.makelivecalls

--- a/tests/commands/test_login.py
+++ b/tests/commands/test_login.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.login import cli as login
 from commands.status import cli as status
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 from neoload_cli_lib import user_data
 from neoload_cli_lib.user_data import get_user_data
 

--- a/tests/commands/test_logs_url.py
+++ b/tests/commands/test_logs_url.py
@@ -4,7 +4,7 @@ import pytest
 from click.testing import CliRunner
 from commands.test_results import cli as results
 from commands.logs_url import cli as logs_url
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 from neoload_cli_lib import user_data
 
 

--- a/tests/commands/test_results/test_result_delete.py
+++ b/tests/commands/test_results/test_result_delete.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.status import cli as status
 from commands.test_results import cli as results
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.results

--- a/tests/commands/test_results/test_result_ls.py
+++ b/tests/commands/test_results/test_result_ls.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.test_results import cli as results
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.results

--- a/tests/commands/test_results/test_result_patch.py
+++ b/tests/commands/test_results/test_result_patch.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from commands.test_results import cli as results
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.results

--- a/tests/commands/test_results/test_result_put.py
+++ b/tests/commands/test_results/test_result_put.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from commands.test_results import cli as results
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.results

--- a/tests/commands/test_settings/test_create.py
+++ b/tests/commands/test_settings/test_create.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from commands.test_settings import cli as settings
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.settings

--- a/tests/commands/test_settings/test_createorpatch.py
+++ b/tests/commands/test_settings/test_createorpatch.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from commands.test_settings import cli as settings
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.makelivecalls

--- a/tests/commands/test_settings/test_delete.py
+++ b/tests/commands/test_settings/test_delete.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 
 from commands.status import cli as status
 from commands.test_settings import cli as settings
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.settings

--- a/tests/commands/test_settings/test_ls.py
+++ b/tests/commands/test_settings/test_ls.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.test_settings import cli as settings
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.settings

--- a/tests/commands/test_settings/test_patch.py
+++ b/tests/commands/test_settings/test_patch.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from commands.test_settings import cli as settings
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.settings

--- a/tests/commands/test_settings/test_put.py
+++ b/tests/commands/test_settings/test_put.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from commands.test_settings import cli as settings
 from commands.status import cli as status
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.settings

--- a/tests/commands/workspaces/test_workspace_ls.py
+++ b/tests/commands/workspaces/test_workspace_ls.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 from commands.workspaces import cli as workspaces
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.workspaces

--- a/tests/commands/workspaces/test_workspace_use.py
+++ b/tests/commands/workspaces/test_workspace_use.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 from commands.status import cli as status
 from commands.workspaces import cli as workspaces
 from commands.logout import cli as logout
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.workspaces

--- a/tests/commands/zones/test_zones.py
+++ b/tests/commands/zones/test_zones.py
@@ -1,7 +1,7 @@
 import pytest
 from click.testing import CliRunner
 from commands.zones import cli as zones
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.zones

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 from commands.login import cli as login
 from commands.status import cli as status
 from commands.config import cli as config
-from helpers.test_utils import mock_login_get_urls
+from tests.helpers.test_utils import mock_login_get_urls
 
 import sys
 

--- a/tests/neoload_cli_lib/test_displayer.py
+++ b/tests/neoload_cli_lib/test_displayer.py
@@ -6,7 +6,7 @@ import sys
 import unicodedata
 
 import pytest
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 from neoload_cli_lib import displayer
 

--- a/tests/neoload_cli_lib/test_user_data.py
+++ b/tests/neoload_cli_lib/test_user_data.py
@@ -1,7 +1,7 @@
 import click
 import pytest
 import neoload_cli_lib.user_data as user_data
-from helpers.test_utils import mock_login_get_urls
+from tests.helpers.test_utils import mock_login_get_urls
 
 
 @pytest.mark.authentication

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -12,7 +12,7 @@ from commands.validate import cli as validate
 from commands.run import cli as run
 from commands.stop import cli as stop
 
-from helpers.test_utils import *
+from tests.helpers.test_utils import *
 
 
 @pytest.mark.acceptance


### PR DESCRIPTION
## What?
Package data was not included as expected for egg-based distro, and unit tests do not cover this type of post-egg-install process.

## Why?
Reported issue with 1.3.1 using "neoload report --template builtin:transactions-csv"

## How?
Made "tests" folder a module itself (added __init__.py) which causes a number of tests to need namespace ref updates. Also add "package_data=True" to setup.py.

## Testing
Pushed 1.3.2rc0 and 1.3.2rc1 tags and distros, then uninstalled local and reinstalled specifically 1.3.2rc1 and ran report command. All other normal testing (unit and live) passed of course.

## Additional Notes
We need to come up with a post-RC integration testing workflow that proves what is installed from egg works for common commands such as this. Unit tests don't cover E2E post-install situations such as this.