### PR TITLE
The releases on pypi should occur only on master or on tags contains '.dev'

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event.base_ref == 'refs/heads/master' || contains(github.ref, '.dev') }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## What?
The official release should be on master branch according to the process we agreed : on weekly 2020-09-24
_Don’t push a pypi rc off of any other branch but master_

## Tests
On my personal github : https://github.com/guillaumebert/neoload-cli/actions
- A tag made on master branch will trigger the release
- A tag on any other branch when the tag name contains ".dev" will trigger a release on pypi
- A tag on any other branch : the pypi release is skipped