### PR TITLE
Fix report pathing and re-run tests

### DIFF
--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -172,7 +172,6 @@ def get_resource_as_string(relative_path):
     file = path[-1]
     logging.debug({'path':path,'namespace':namespace,'file':file})
     contents = pkg_resources.read_text(namespace, file)
-    logging.debug("get_resource_as_string[contents]: {}".format(contents))
     return contents
 
 def split_path(path):

--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -166,11 +166,17 @@ def get_resource_as_string(relative_path):
         # Try backported to PY<37 `importlib_resources`.
         import importlib_resources as pkg_resources
 
-    path = relative_path.split(os.path.sep)
+    path = split_path(relative_path)
     namespace = ".".join(path[:-1])
     file = path[-1]
     logging.debug({'path':path,'namespace':namespace,'file':file})
     return pkg_resources.read_text(namespace, file)
+
+def split_path(path):
+    sep = os.path.sep
+    if sep not in path: sep = '/' # try internal posix style
+    if sep not in path: sep = '\\' # try Windows style (resolves to a single slash)
+    return path.split(sep)
 
 def parse_template_spec(model,filter_spec,template):
     if template.lower().startswith("builtin:transactions"):

--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -166,11 +166,14 @@ def get_resource_as_string(relative_path):
         # Try backported to PY<37 `importlib_resources`.
         import importlib_resources as pkg_resources
 
+
     path = split_path(relative_path)
     namespace = ".".join(path[:-1])
     file = path[-1]
     logging.debug({'path':path,'namespace':namespace,'file':file})
-    return pkg_resources.read_text(namespace, file)
+    contents = pkg_resources.read_text(namespace, file)
+    logging.debug("get_resource_as_string[contents]: {}".format(contents))
+    return contents
 
 def split_path(path):
     sep = os.path.sep

--- a/tests/commands/docker/test_docker_cleanups.py
+++ b/tests/commands/docker/test_docker_cleanups.py
@@ -11,6 +11,7 @@ import tempfile
 
 @pytest.mark.docker
 @pytest.mark.slow
+@pytest.mark.makelivecalls
 @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
 class TestDockerCleanups:
     def test_docker_clean(self):

--- a/tests/commands/docker/test_docker_hooks.py
+++ b/tests/commands/docker/test_docker_hooks.py
@@ -11,6 +11,7 @@ import tempfile
 
 @pytest.mark.docker
 @pytest.mark.slow
+@pytest.mark.makelivecalls
 @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
 class TestDockerHooks:
     def test_docker_install(self):


### PR DESCRIPTION
## What?
Fix issue with path separators as reported by Issue #174 

## Why?
On Windows machines, path separator wasn't being taken into account as a backslash.

## How?
Check all system path separators in relative resource URIs for report templates so that no matter which system it is run on, the resource namespace is derived from the relative path (i.e. tests/resources/jinja/builtin_transactions_csv.j2) properly.

## Testing
Installed on a Win2016 server and verified working now manually. All other unit tests passing. Also, updated two docker-based tests to be run under the same [integration] model as the other tests which rely on Docker, so that unit test suite passes if Docker is not installed or running.

## Additional Notes
This is another thing that would be caught by unit and integration tests if we start using an additional Windows build node in the build and test workflows. Closes #174 