### PR TITLE
Load 25091

### DIFF
--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -41,7 +41,7 @@ def load_from_file(file):
 @click.option('--external-url', 'external_url', help="URL to an external system, for example the CI job's link")
 @click.option('--external-url-label', 'external_url_label',
               help="Label to describe the external URL, for example the CI name or job ID")
-@click.option('--lock/--unlock', default=False, help="Protect a specific result to avoid automatic or accidental manual deletion")
+@click.option('--lock/--unlock', default=None, help="Protect a specific result to avoid automatic or accidental manual deletion")
 def cli(command, name, rename, description, quality_status, junit_file, file, filter, external_url, external_url_label, lock):
     """
     ls       # Lists test results                                            .

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -201,11 +201,11 @@ def get_end_point(id_test: str = None, operation=''):
     slash_id_test = '' if id_test is None else '/' + id_test
     return rest_crud.base_endpoint_with_workspace() + __endpoint + slash_id_test + operation
 
-def prompt_is_locked(field):
+def prompt_boolean(field):
     is_locked = tools.string_to_bool_json(input(field))
     while is_locked is None :
-        print("\n (Accepted value for true : )", tools.get_true_values())
-        print("\n (Accepted value for false : )", tools.get_false_values())
+        print("\n Accepted values for true: ", tools.get_true_values())
+        print("\n Accepted values for false: ", tools.get_false_values())
         is_locked = tools.string_to_bool_json(input(field))
     return is_locked
 
@@ -226,7 +226,7 @@ def create_json(name, description, quality_status, external_url, external_url_la
     if len(data) == 0 and sys.stdin.isatty():
         for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel', 'isLocked']:
             if field == 'isLocked':
-                data[field] = prompt_is_locked(field)
+                data[field] = prompt_boolean(field)
             else:
                 data[field] = input(field)
     return data

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -201,6 +201,13 @@ def get_end_point(id_test: str = None, operation=''):
     slash_id_test = '' if id_test is None else '/' + id_test
     return rest_crud.base_endpoint_with_workspace() + __endpoint + slash_id_test + operation
 
+def prompt_is_locked(field):
+    is_locked = tools.string_to_bool_json(input(field))
+    while is_locked is None :
+        print("\n (Accepted value for true : )", tools.get_true_values())
+        print("\n (Accepted value for false : )", tools.get_false_values())
+        is_locked = tools.string_to_bool_json(input(field))
+    return is_locked
 
 def create_json(name, description, quality_status, external_url, external_url_label, lock):
     data = {}
@@ -219,12 +226,7 @@ def create_json(name, description, quality_status, external_url, external_url_la
     if len(data) == 0 and sys.stdin.isatty():
         for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel', 'isLocked']:
             if field == 'isLocked':
-                isLocked = tools.string_to_bool_json(input(field))
-                while(isLocked is None):
-                    print("\n (Accepted value for true : )", tools.get_true_values())
-                    print("\n (Accepted value for false : )", tools.get_false_values())
-                    isLocked = tools.string_to_bool_json(input(field))
-                data[field] = isLocked
+                data[field] = prompt_is_locked(field)
             else:
                 data[field] = input(field)
     return data

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -219,11 +219,11 @@ def create_json(name, description, quality_status, external_url, external_url_la
     if len(data) == 0 and sys.stdin.isatty():
         for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel', 'isLocked']:
             if field == 'isLocked':
-                isLocked = tools.string_to_bool(input(field))
+                isLocked = tools.string_to_bool_json(input(field))
                 while(isLocked is None):
                     print("\n (Accepted value for true : )", tools.get_true_values())
                     print("\n (Accepted value for false : )", tools.get_false_values())
-                    isLocked = tools.string_to_bool(input(field))
+                    isLocked = tools.string_to_bool_json(input(field))
                 data[field] = isLocked
             else:
                 data[field] = input(field)

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -41,7 +41,8 @@ def load_from_file(file):
 @click.option('--external-url', 'external_url', help="URL to an external system, for example the CI job's link")
 @click.option('--external-url-label', 'external_url_label',
               help="Label to describe the external URL, for example the CI name or job ID")
-def cli(command, name, rename, description, quality_status, junit_file, file, filter, external_url, external_url_label):
+@click.option('--lock/--unlock', default=False, help="Protect a specific result to avoid automatic or accidental manual deletion")
+def cli(command, name, rename, description, quality_status, junit_file, file, filter, external_url, external_url_label, lock):
     """
     ls       # Lists test results                                            .
     summary  # Display a summary of the result : SLAs and statistics         .
@@ -83,7 +84,7 @@ def cli(command, name, rename, description, quality_status, junit_file, file, fi
         user_data.set_meta(meta_key, None)
     else:
         json_data = load_from_file(file) if file else create_json(rename, description, quality_status, external_url,
-                                                                  external_url_label)
+                                                                  external_url_label, lock)
         print_compatibility_warning_for_old_nlw(json_data)
 
         if command == "put":
@@ -201,7 +202,7 @@ def get_end_point(id_test: str = None, operation=''):
     return rest_crud.base_endpoint_with_workspace() + __endpoint + slash_id_test + operation
 
 
-def create_json(name, description, quality_status, external_url, external_url_label):
+def create_json(name, description, quality_status, external_url, external_url_label, lock):
     data = {}
     if name is not None:
         data['name'] = name
@@ -213,6 +214,8 @@ def create_json(name, description, quality_status, external_url, external_url_la
         data['externalUrl'] = external_url
     if external_url_label is not None:
         data['externalUrlLabel'] = external_url_label
+    if lock is not None:
+        data['isLocked'] = lock
     if len(data) == 0 and sys.stdin.isatty():
         for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel']:
             data[field] = input(field)

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -217,8 +217,16 @@ def create_json(name, description, quality_status, external_url, external_url_la
     if lock is not None:
         data['isLocked'] = lock
     if len(data) == 0 and sys.stdin.isatty():
-        for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel']:
-            data[field] = input(field)
+        for field in ['name', 'description', 'qualityStatus', 'externalUrl', 'externalUrlLabel', 'isLocked']:
+            if field == 'isLocked':
+                isLocked = tools.string_to_bool(input(field))
+                while(isLocked is None):
+                    print("\n (Accepted value for true : )", tools.get_true_values())
+                    print("\n (Accepted value for false : )", tools.get_false_values())
+                    isLocked = tools.string_to_bool(input(field))
+                data[field] = isLocked
+            else:
+                data[field] = input(field)
     return data
 
 

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -181,6 +181,18 @@ def system_exit(exit_process, apply_exit_code=True):
 def get_boolean_value_from_env(env_var, default=False):
     return os.getenv(env_var, str(default)).lower().strip() in __true_values
 
+def string_to_bool(str):
+    if str in __true_values:
+        return True
+    if str in __false_values:
+        return False
+    return None
+
+def get_true_values():
+    return __true_values
+
+def get_false_values():
+    return __false_values
 
 def is_user_interactive():
     return get_boolean_value_from_env(__nl_interactive_env_var, False) or config_global.get_attr("interactive", False)

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -181,7 +181,7 @@ def system_exit(exit_process, apply_exit_code=True):
 def get_boolean_value_from_env(env_var, default=False):
     return os.getenv(env_var, str(default)).lower().strip() in __true_values
 
-def string_to_bool(str):
+def string_to_bool_json(str):
     if str in __true_values:
         return True
     if str in __false_values:

--- a/tests/commands/test_results/test_result_patch.py
+++ b/tests/commands/test_results/test_result_patch.py
@@ -111,4 +111,4 @@ class TestResultPatch:
         runner = CliRunner()
         result = runner.invoke(results, ['patch', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert "Invalid value for \"--quality-status\": invalid choice: not_valid_quality. (choose from PASSED, FAILED)" in result.output
+        assert 'Invalid value for "--quality-status": invalid choice: not_valid_quality. (choose from PASSED, FAILED)' in result.output

--- a/tests/commands/test_results/test_result_patch.py
+++ b/tests/commands/test_results/test_result_patch.py
@@ -45,11 +45,11 @@ class TestResultPatch:
         test_name = generate_test_result_name()
         mock_api_patch(monkeypatch, 'v2/test-results/%s' % valid_data.test_result_id,
                        '{"id":"70ed01da-f291-4e29-b75c-1f7977edf252","name":"%s","description":"test description patch ",'
-                       '"qualityStatus":"FAILED","externalUrl":"http://url","externalUrlLabel":"external_lib"}' % test_name)
+                       '"qualityStatus":"FAILED","externalUrl":"http://url","externalUrlLabel":"external_lib", "isLocked":"true"}' % test_name)
         result = runner.invoke(results,
                                ['patch', valid_data.test_result_id, '--description', 'test description patch ',
                                 '--quality-status', 'FAILED', '--rename', test_name, '--external-url', 'http://url',
-                                '--external-url-label', 'external_lib'])
+                                '--external-url-label', 'external_lib', '--lock'])
         assert_success(result)
         json_result = json.loads(result.output)
         assert json_result['name'] == test_name
@@ -57,6 +57,7 @@ class TestResultPatch:
         assert json_result['qualityStatus'] == 'FAILED'
         assert json_result['externalUrl'] == 'http://url'
         assert json_result['externalUrlLabel'] == 'external_lib'
+        assert json_result['isLocked'] == 'true'
 
     def test_input_map(self, monkeypatch, valid_data):
         runner = CliRunner()
@@ -66,10 +67,10 @@ class TestResultPatch:
         test_name = generate_test_result_name()
         mock_api_patch(monkeypatch, 'v2/test-results/%s' % valid_data.test_result_id,
                        '{"id":"70ed01da-f291-4e29-b75c-1f7977edf252", "name":"%s", "description":"test description ",'
-                       '"qualityStatus":"PASSED","externalUrl":"http://url2","externalUrlLabel":"external_lib2"}' % test_name)
+                       '"qualityStatus":"PASSED","externalUrl":"http://url2","externalUrlLabel":"external_lib2", "isLocked":"true"}' % test_name)
         result = runner.invoke(results, ['patch'], input='{"name":"%s", "description":"test description ",'
                                                          '"qualityStatus":"PASSED","externalUrl":"http://url2",'
-                                                         '"externalUrlLabel":"external_lib2"}' % test_name)
+                                                         '"externalUrlLabel":"external_lib2", "isLocked":"true"}' % test_name)
         assert_success(result)
         json_result = json.loads(result.output)
         assert json_result['name'] == test_name
@@ -77,6 +78,7 @@ class TestResultPatch:
         assert json_result['qualityStatus'] == 'PASSED'
         assert json_result['externalUrl'] == 'http://url2'
         assert json_result['externalUrlLabel'] == 'external_lib2'
+        assert json_result['isLocked'] == 'true'
 
     def test_error_invalid_json(self, valid_data):
         runner = CliRunner()
@@ -109,4 +111,4 @@ class TestResultPatch:
         runner = CliRunner()
         result = runner.invoke(results, ['patch', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert "Invalid value for '--quality-status': 'not_valid_quality' is not one of 'PASSED', 'FAILED'" in result.output
+        assert "Invalid value for \"--quality-status\": invalid choice: not_valid_quality. (choose from PASSED, FAILED)" in result.output

--- a/tests/commands/test_results/test_result_patch.py
+++ b/tests/commands/test_results/test_result_patch.py
@@ -111,4 +111,4 @@ class TestResultPatch:
         runner = CliRunner()
         result = runner.invoke(results, ['patch', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert 'Invalid value for "--quality-status": invalid choice: not_valid_quality. (choose from PASSED, FAILED)' in result.output
+        assert "Invalid value for '--quality-status': 'not_valid_quality' is not one of 'PASSED', 'FAILED'" in result.output

--- a/tests/commands/test_results/test_result_put.py
+++ b/tests/commands/test_results/test_result_put.py
@@ -113,4 +113,4 @@ class TestResultPut:
         runner = CliRunner()
         result = runner.invoke(results, ['put', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert 'Invalid value for "--quality-status": invalid choice: not_valid_quality. (choose from PASSED, FAILED)' in result.output
+        assert "Invalid value for '--quality-status': 'not_valid_quality' is not one of 'PASSED', 'FAILED'" in result.output

--- a/tests/commands/test_results/test_result_put.py
+++ b/tests/commands/test_results/test_result_put.py
@@ -113,4 +113,4 @@ class TestResultPut:
         runner = CliRunner()
         result = runner.invoke(results, ['put', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert "Invalid value for \"--quality-status\": invalid choice: not_valid_quality. (choose from PASSED, FAILED)" in result.output
+        assert 'Invalid value for "--quality-status": invalid choice: not_valid_quality. (choose from PASSED, FAILED)' in result.output

--- a/tests/commands/test_results/test_result_put.py
+++ b/tests/commands/test_results/test_result_put.py
@@ -47,11 +47,11 @@ class TestResultPut:
         test_name = generate_test_result_name()
         mock_api_put(monkeypatch, 'v2/test-results/%s' % valid_data.test_result_id,
                      '{"id":"70ed01da-f291-4e29-b75c-1f7977edf252", "name":"%s", "description":"test description put ",'
-                     '"qualityStatus":"FAILED","externalUrl":"http://url","externalUrlLabel":"external_lib"}' % test_name)
+                     '"qualityStatus":"FAILED","externalUrl":"http://url","externalUrlLabel":"external_lib", "isLocked":"true"}' % test_name)
         result = runner.invoke(results,
                                ['put', valid_data.test_result_id, '--description', 'test description patch ',
                                 '--quality-status', 'FAILED', '--rename', test_name, '--external-url', 'http://url',
-                                '--external-url-label', 'external_lib'])
+                                '--external-url-label', 'external_lib' , '--lock']) 
         assert_success(result)
         json_result = json.loads(result.output)
         assert json_result['name'] == test_name
@@ -59,6 +59,7 @@ class TestResultPut:
         assert json_result['qualityStatus'] == 'FAILED'
         assert json_result['externalUrl'] == 'http://url'
         assert json_result['externalUrlLabel'] == 'external_lib'
+        assert json_result['isLocked'] == 'true'
 
     def test_input_map(self, monkeypatch, valid_data):
         runner = CliRunner()
@@ -68,10 +69,10 @@ class TestResultPut:
         test_name = generate_test_result_name()
         mock_api_put(monkeypatch, 'v2/test-results/%s' % valid_data.test_result_id,
                      '{"id":"70ed01da-f291-4e29-b75c-1f7977edf252", "name":"%s", "description":"test description ",'
-                     '"qualityStatus":"PASSED","externalUrl":"http://url2","externalUrlLabel":"external_lib2"}' % test_name)
+                     '"qualityStatus":"PASSED","externalUrl":"http://url2","externalUrlLabel":"external_lib2", "isLocked":"true"}' % test_name)
         result = runner.invoke(results, ['put'], input='{"name":"%s", "description":"test description ",'
                                                        '"qualityStatus":"PASSED","externalUrl":"http://url2",'
-                                                       '"externalUrlLabel":"external_lib2"}' % test_name)
+                                                       '"externalUrlLabel":"external_lib2", "isLocked":"true"}' % test_name)
         assert_success(result)
         json_result = json.loads(result.output)
         assert json_result['name'] == test_name
@@ -79,6 +80,7 @@ class TestResultPut:
         assert json_result['qualityStatus'] == 'PASSED'
         assert json_result['externalUrl'] == 'http://url2'
         assert json_result['externalUrlLabel'] == 'external_lib2'
+        assert json_result['isLocked'] == 'true'
 
     def test_error_invalid_json(self, valid_data):
         runner = CliRunner()
@@ -111,4 +113,4 @@ class TestResultPut:
         runner = CliRunner()
         result = runner.invoke(results, ['put', '--quality-status', 'not_valid_quality'])
         assert result.exit_code == 2
-        assert "Invalid value for '--quality-status': 'not_valid_quality' is not one of 'PASSED', 'FAILED'" in result.output
+        assert "Invalid value for \"--quality-status\": invalid choice: not_valid_quality. (choose from PASSED, FAILED)" in result.output

--- a/tests/neoload_cli_lib/test_tools.py
+++ b/tests/neoload_cli_lib/test_tools.py
@@ -1,4 +1,5 @@
 import os
+from neoload.neoload_cli_lib.tools import string_to_bool_json
 
 from neoload_cli_lib import tools
 
@@ -81,3 +82,15 @@ class TestTools:
         mocks = {'TRAVIS': 'True'}
         monkeypatch.setattr(os, 'getenv', lambda var, default=None: mock_get_env(mocks, var, default))
         assert tools.are_any_ci_env_vars_active() is True
+
+def test_string_to_boolean_json():
+    list_unknown_values = {'value1', '123', 'random'}
+
+    for unknow_value in list_unknown_values:
+        assert string_to_bool_json(unknow_value) is None
+
+    for true_value in tools.get_true_values():
+        assert string_to_bool_json(true_value) is True
+
+    for false_value in tools.get_false_values():
+        assert string_to_bool_json(false_value) is False


### PR DESCRIPTION
## What?
Implementation of option lock/unlock for command test-results. ( Put & Patch )

## Why?
We needed to permits users to protect specific test-results from deletion.

## How?
Added option --lock/--unlock with "click" (package in python), then update "create_json" method  used when put and patch . 

## Testing
Modification in test_results_patch and test_results_put.