### PR TITLE
Featuregroup/load 25592

### DIFF
--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -24,7 +24,7 @@ from neoload_cli_lib import running_tools, tools, rest_crud, user_data, hooks
 @click.option('--external-url-label', 'external_url_label',
               help="Label to describe the external URL, for example the CI name or job ID")
 @click.option('--lock', is_flag=True, default=None,
-              help="Protect the result of this run to avoid automatic or accidental manual deletion. If the test failed to start it won't lock unless you use option '-d/--detach'.")
+              help="Protect the result of this run to avoid automatic or accidental manual deletion. If the test failed to start it won't lock unless you use option '-d/--detached'.")
 
 def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_vu, citrix_vu, return_0, external_url,
         external_url_label, lock):

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -66,6 +66,7 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
     if not detached:
         running_tools.wait(post_result['resultId'], not return_0, data_lock)
     else:
+        patch_data(post_result['resultId'], data_lock)
         tools.print_json(post_result)
 
 

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -24,7 +24,7 @@ from neoload_cli_lib import running_tools, tools, rest_crud, user_data, hooks
 @click.option('--external-url-label', 'external_url_label',
               help="Label to describe the external URL, for example the CI name or job ID")
 @click.option('--lock', is_flag=True, default=None,
-              help="Protect the result of this run to avoid automatic or accidental manual deletion")
+              help="Protect the result of this run to avoid automatic or accidental manual deletion. If the test failed to start it won't lock unless you use option '-d/--detach'.")
 
 def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_vu, citrix_vu, return_0, external_url,
         external_url_label, lock):


### PR DESCRIPTION
## What?
Fix --lock run (do not lock result if they are aborted + need lock if run detach) 

## Why?
When a test is aborted without being in running state, the test still lock itself.
Need to fix this bug cause it permits to not unlock all result that failed for random reasons if user wants to delete them.
Also, if you run test with detach option the test was not locked !