### PR TITLE
Add --reservation-id and --reservation-duration options to 'run' command

### DIFF
--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -25,9 +25,11 @@ from neoload_cli_lib import running_tools, tools, rest_crud, user_data, hooks
               help="Label to describe the external URL, for example the CI name or job ID")
 @click.option('--lock', is_flag=True, default=None,
               help="Protects the Test Result to avoid automatic or accidental manual deletion. In interactive mode (not detached), the Test Result won't be protected if the run fails to start.")
+@click.option("--reservation-id", 'reservation_id', help="The reservation identifier to use for the test that can be retrieved from the NeoLoad Web reservation calendar URL (if the reservation mode is enabled)")
+@click.option("--reservation-duration", 'reservation_duration', help="The duration (in seconds) of the reservation for the test (if the reservation mode is enabled)")
 
 def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_vu, citrix_vu, return_0, external_url,
-        external_url_label, lock):
+        external_url_label, lock, reservation_id, reservation_duration):
     """run a test"""
     rest_crud.set_current_command()
     if not name_or_id or name_or_id == "cur":
@@ -49,7 +51,7 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
 
     # Sorry for that, post data are in the query string :'( :'(
     post_result = rest_crud.post(
-        test_settings.get_end_point(_id) + '/start?' + create_data(naming_pattern, description, as_code, web_vu, sap_vu, citrix_vu),
+        test_settings.get_end_point(_id) + '/start?' + create_data(naming_pattern, description, as_code, web_vu, sap_vu, citrix_vu, reservation_id, reservation_duration),
         {})
     user_data.set_meta(test_settings.meta_key, _id)
     user_data.set_meta(test_results.meta_key, post_result['resultId'])
@@ -70,7 +72,7 @@ def cli(name_or_id, scenario, detached, name, description, as_code, web_vu, sap_
         tools.print_json(post_result)
 
 
-def create_data(name, description, as_code, web_vu, sap_vu, citrix_vu):
+def create_data(name, description, as_code, web_vu, sap_vu, citrix_vu, reservation_id, reservation_duration):
     query = 'testResultName=' + quote(name)
     if description is not None:
         query += '&testResultDescription=' + quote(description)
@@ -83,6 +85,10 @@ def create_data(name, description, as_code, web_vu, sap_vu, citrix_vu):
     if citrix_vu is not None:
         logging.getLogger().warning('WARNING: --cirix-vu is deprecated')
         query += '&reservationCitrixVUs=' + citrix_vu
+    if reservation_id is not None:
+        query += '&reservationId=' + reservation_id
+    if reservation_duration is not None:
+        query += '&reservationDuration=' + reservation_duration
     return query
 
 

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -29,7 +29,17 @@ class TestRun:
         web_vu = "10"
         sap_vu = "10"
         citrix_vu= "10"
-        create_data_query = create_data(name,description,as_code, web_vu, sap_vu, citrix_vu)
-        expected_query = "testResultName=result_13&testResultDescription=test_descript&asCode=0&reservationWebVUs=10&reservationSAPVUs=10&reservationCitrixVUs=10"
+        reservation_duration = "1200"
+        reservation_id = "resaId"
+        create_data_query = create_data(name, description, as_code, web_vu, sap_vu, citrix_vu, reservation_id,
+                                        reservation_duration)
+        expected_query = "testResultName=result_13&testResultDescription=test_descript&asCode=0&reservationWebVUs=10" \
+                         "&reservationSAPVUs=10&reservationCitrixVUs=10&reservationId=resaId&reservationDuration=1200"
+
+        assert (create_data_query == expected_query) is True
+
+    def test_create_data_empty(self):
+        create_data_query = create_data("resultname", None, None, None, None, None, None, None)
+        expected_query = "testResultName=resultname"
 
         assert (create_data_query == expected_query) is True


### PR DESCRIPTION
## What?
Addition of two reservation options for the "run" command.

## Why?
These two options were missing, specially when NLWeb is configured to use reservation feature.

## How?
We juste add the two missing options that are already available on NLWeb rest public api.
