### PR TITLE
Add logging debug when SIGINT is recieved

### DIFF
--- a/neoload/neoload_cli_lib/running_tools.py
+++ b/neoload/neoload_cli_lib/running_tools.py
@@ -1,6 +1,6 @@
 import datetime
+import logging
 import time
-from urllib.parse import quote
 import webbrowser
 from signal import signal, SIGINT
 
@@ -27,6 +27,7 @@ def __lock_result(results_id, data_lock):
 
 def handler(signal_received, frame):
     global __count
+    logging.debug("Ctrl+C is pressed or SIGINT is handled")
     if __current_id:
         inc = stop(__current_id, __count > 0, True)
         if inc:


### PR DESCRIPTION
## What?
Add logging debug when SIGINT is recieved

## Why?
Even if debug mode is activated, when pipeline is killed we haven't any information of what's happening.
