### PR TITLE
Fix git parser for python 3.11

### DIFF
--- a/neoload/neoload_cli_lib/neoLoad_project.py
+++ b/neoload/neoload_cli_lib/neoLoad_project.py
@@ -3,7 +3,7 @@ import tempfile
 import zipfile
 
 import logging
-from gitignore_parser import parse_gitignore
+import gitignorefile
 
 from neoload_cli_lib import rest_crud, tools, cli_exception
 import shutil
@@ -37,7 +37,7 @@ def zip_dir(path,save):
 
     # find and load .nlignore
     ignore_file = os.path.join(path, '.nlignore')
-    nl_ignore_matcher = parse_gitignore(ignore_file) if os.path.exists(ignore_file) else None
+    nl_ignore_matcher = gitignorefile.parse(ignore_file) if os.path.exists(ignore_file) else None
 
     compress_project(nl_ignore_matcher, path, file_stream)
 

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -12,7 +12,7 @@ from neoload_cli_lib.user_data import update_schema, get_yaml_schema, tools
 import logging
 import hashlib
 import os
-from gitignore_parser import parse_gitignore
+import  gitignorefile
 from neoload_cli_lib.neoLoad_project import is_not_to_be_included
 
 YAML_NOT_CONFIRM_MESSAGE = "YAML does not confirm to NeoLoad DSL schema."
@@ -54,7 +54,7 @@ def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
 
 def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
     ignore_file = os.path.join(path, '.nlignore')
-    nl_ignore_matcher = parse_gitignore(ignore_file) if os.path.exists(ignore_file) else None
+    nl_ignore_matcher =  gitignorefile.parse(ignore_file) if os.path.exists(ignore_file) else None
     first_time_check = True
     extensions = ['yml','yaml','json']
     any_errs = False

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'junit_xml',
         'termcolor',
         'coloredlogs',
-        'gitignore_parser',
+        'gitignorefile',
         'jinja2',
         'python-dateutil', # for 3.6 compatibility
         'tqdm',

--- a/tests/commands/project/test_upload.py
+++ b/tests/commands/project/test_upload.py
@@ -7,6 +7,7 @@ from tests.helpers.test_utils import *
 from neoload_cli_lib import neoLoad_project
 import os, tempfile, time
 
+
 @pytest.mark.project
 class TestUpload:
 
@@ -35,23 +36,46 @@ class TestUpload:
         assert_success(result_status)
         assert 'settings id: %s' % valid_data.test_settings_id in result_status.output
 
+    @pytest.mark.datafiles('tests/neoload_projects/')
+    @pytest.mark.usefixtures("neoload_login")  # it's like @Before on the neoload_login function
+    def test_upload_files(self, monkeypatch, datafiles, valid_data):
+        runner = CliRunner()
+        mock_api_post_binary(monkeypatch, 'v2/tests/%s/project' % valid_data.test_settings_id, 200,
+                             '{"projectId":"5e5fc0102cc4f82e5d9e18d4", "projectName":"NeoLoad-CLI-example-2_0",'
+                             '"asCodeFiles": [{"path": "default.yaml", "includes": ["paths/geosearch_get.yaml"]}],'
+                             '"scenarios":[{"scenarioName": "sanityScenario","scenarioDuration": 10,"scenarioVUs": 2,"scenarioSource": "default.yaml"}]}')
+
+        result_upload = runner.invoke(project, ['--path', datafiles, 'upload', valid_data.test_settings_id])
+        assert_success(result_upload)
+        json_upload = json.loads(result_upload.output)
+        assert json_upload['projectName'] == 'NeoLoad-CLI-example-2_0'
+        assert str(json_upload['asCodeFiles'][0]['path']).endswith('default.yaml')
+        assert json_upload['asCodeFiles'][0]['includes'][0] == 'paths/geosearch_get.yaml'
+        assert json_upload['scenarios'][0]['scenarioName'] == 'sanityScenario'
+        assert json_upload['scenarios'][0]['scenarioDuration'] == 10
+        assert json_upload['scenarios'][0]['scenarioVUs'] == 2
+        assert str(json_upload['scenarios'][0]['scenarioSource']).endswith('default.yaml')
+
+        result_status = runner.invoke(status)
+        assert_success(result_status)
+        assert 'settings id: %s' % valid_data.test_settings_id in result_status.output
 
     @pytest.mark.datafiles('tests/neoload_projects/example_1.zip')
     def test_upload_with_save(self, monkeypatch, datafiles):
         source_path = datafiles.listdir()[0]
 
-        file = tempfile.NamedTemporaryFile(delete=False,suffix='.zip')
+        file = tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
         basename = file.name
 
-        try: # negative test case
-            neoLoad_project.zip_dir(source_path,basename+".bad")
+        try:  # negative test case
+            neoLoad_project.zip_dir(source_path, basename + ".bad")
             assert False, "Bad extension should have been rejected, but wasn't"
         except:
-            assert True
+            pass
 
         os.remove(basename)
-        neoLoad_project.zip_dir(source_path,basename)
+        neoLoad_project.zip_dir(source_path, basename)
         exists = os.path.exists(basename)
-        os.remove(basename) # pre-emptive cleanup
+        os.remove(basename)  # pre-emptive cleanup
 
         assert exists, "File does not exist! [{}]".format(basename)

--- a/tests/neoload_projects/.nlignore
+++ b/tests/neoload_projects/.nlignore
@@ -1,1 +1,3 @@
 .gitlab-ci.yml
+.cache/**
+.local/**


### PR DESCRIPTION
## What?
Git parser library is not compatible to python 3.11. 
This patch use gitignorefile library instead.