### PR TITLE
If conditional

### DIFF
--- a/examples/pipelines/github/neoload-github-actions-demo.yml
+++ b/examples/pipelines/github/neoload-github-actions-demo.yml
@@ -44,12 +44,15 @@ jobs:
           --return-0
 
       - name: "Generate Test Report"
+        id: report
         if: ${{ always() }}
         run: neoload test-results junitsla
 
       - name: "Publish Test Report"
-        if: ${{ always() }}
+        if: steps.report.outcome == 'success'
         uses: scacap/action-surefire-report@v1
         with:
           report_paths: junit-sla.xml
           fail_on_test_failures: true
+
+

--- a/examples/pipelines/github/neoload-github-actions-demo.yml
+++ b/examples/pipelines/github/neoload-github-actions-demo.yml
@@ -44,6 +44,7 @@ jobs:
           --return-0
 
       - name: "Generate Test Report"
+        if: ${{ always() }}
         run: neoload test-results junitsla
 
       - name: "Publish Test Report"


### PR DESCRIPTION
## What?
Including an if condition to workflow examples for Github actions, as otherwise it would not work as well as an id to the last step changing if on last job success

## Why?
If Neoload test fails it will not generate a test case, while the other step will run making the workflow freeze until it times out, where even cancel workflow does not seem to work at times. But if we leave 2 always if conditionals for generate and publish report and something goes wrong with .yaml system file or some other human errors, syntax errors the generate report will fail but the Publish test will still run, so lets create an id for test report generate and run only success, Publish report does not seem to fail gracefully.

## How?
By simply adding another if always condition, defining an id for report generate and running  publish report only on success.

## Testing
Testing with production pipelines in an enterprise org. Tested with failed tests and successful tests.

## Additional Notes
scacap/action-surefire-report@v1 has some issues on its own with private repositories and github tokens and the code owner has not addressed some issues reported, it might be better to write pr check via api by hand rather than re-using this action. In a way I would say its pretty redundant as Neoloadhas its own front-end for test reports and everything is displayed in the web front-end. That is how SonarQube operates - pipeline for the test and reporting is in the web rather than using Github for displaying reports
