### PR TITLE
Markdown support for --external-url in neoload run and neoload test-results

### DIFF
--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import re
 from urllib.parse import quote
 
 import click
@@ -100,7 +101,7 @@ def prepare_external_url(data, external_url, external_url_label):
             data['externalUrlLabel'] = match.group(1)
         else:
             data['externalUrl'] = external_url
-            data['externalUrlLabel'] = ''
+            data['externalUrlLabel'] = external_url_label
     else:
         data['externalUrlLabel'] = external_url_label
 

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -94,8 +94,14 @@ def create_data(name, description, as_code, web_vu, sap_vu, citrix_vu, reservati
 
 def prepare_external_url(data, external_url, external_url_label):
     if external_url is not None:
-        data['externalUrl'] = external_url
-    if external_url_label is not None:
+        match = re.match(r'\[(.*)\]\((.*)\)', external_url)
+        if match:
+            data['externalUrl'] = match.group(2)
+            data['externalUrlLabel'] = match.group(1)
+        else:
+            data['externalUrl'] = external_url
+            data['externalUrlLabel'] = ''
+    else:
         data['externalUrlLabel'] = external_url_label
 
 def prepare_lock(data, lock):

--- a/neoload/commands/run.py
+++ b/neoload/commands/run.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import re
 from urllib.parse import quote
 
 import click

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+import re
 
 import click
 
@@ -221,8 +222,14 @@ def create_json(name, description, quality_status, external_url, external_url_la
     if quality_status is not None:
         data['qualityStatus'] = quality_status
     if external_url is not None:
-        data['externalUrl'] = external_url
-    if external_url_label is not None:
+        match = re.match(r'\[(.*)\]\((.*)\)', external_url)
+        if match:
+            data['externalUrl'] = match.group(2)
+            data['externalUrlLabel'] = match.group(1)
+        else:
+            data['externalUrl'] = external_url
+            data['externalUrlLabel'] = ''
+    else:
         data['externalUrlLabel'] = external_url_label
     if lock is not None:
         data['isLocked'] = lock

--- a/neoload/commands/test_results.py
+++ b/neoload/commands/test_results.py
@@ -38,7 +38,7 @@ def load_from_file(file):
 @click.option('--file', type=click.File('r'), help="Json file with the data to be sent to the API.")
 @click.option('--filter',
               help="Filter test results by fields. Mostly used filters are : name, scenario, project, status.")
-@click.option('--external-url', 'external_url', help="URL to an external system, for example the CI job's link")
+@click.option('--external-url', 'external_url', help="URL to an external system, for example the CI job's link, you can also use markdown format [label](url)")
 @click.option('--external-url-label', 'external_url_label',
               help="Label to describe the external URL, for example the CI name or job ID")
 @click.option('--lock/--unlock', default=None,


### PR DESCRIPTION
## What?
Markdown support for --external-url in neoload run and neoload test-results

## Why?
This change allows users to set the external URL of a test result with Markdown syntax directly from the command line. This simplifies the process of setting the external URL, especially when it is a long or complex URL.

## How?
The change involves updating the prepare_external_url function in neoload/commands/run.py to handle Markdown syntax. The function now extracts the URL and label from the Markdown syntax and sets the externalUrl and externalUrlLabel properties of the data object accordingly.

The change also updates the create_json function in neoload/commands/test_results.py to handle the new format of the external_url property. The function now extracts the label from the external_url property and adds it to the externalUrlLabel property of the data object.

## Testing
Tested: 

- Setting the external URL with Markdown syntax
- Setting the external URL label separately
- Setting the external URL to an empty string
- Setting the external URL to an invalid URL

## Additional Notes
The change does not introduce any new regression issues. The change is backward-compatible with existing usage of the --external-url option.
