### PR TITLE
Make maxWorkers configurable from environment property

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ The 'report' subcommand is intended to simplify not only common data exporting n
  templating capabilities over a standard, correlated data model. In contrast to the test-results
  subcommand, 'report' can be used to generate as well as transform test result data.
 
+:warning: The 'report' subcommand can be **slow** (several hours) on results with a lots of transactions or monitors.
+
 ### Exporting Transaction CSV data
 ```
 Usage: neoload report [OPTIONS] [NAME]
@@ -288,6 +290,20 @@ neoload report --json-in ~/Downloads/temp.json \
 
 NOTE: built-in reports produce a reduced-scope JSON data model and are therefore faster
  that exporting all test data for various templates and output specs.
+
+### Work with big results
+
+Big results for the CLI means several hundreds of transactions, with several LGs and last several hours.
+
+The 'report' subcommand get a lot of data from NeoLoad Web API, it is not recommended to use with big results
+because it could take several hours to complete and may fail.
+
+The 'report' subcommand gets all "values" and the "timeseries points" of all statistics from NLW API for each transaction and monitor: \
+it makes 2 API calls per transaction and 1 API call per monitor to NLW API. 10 calls are made in parallel
+(can be configured with env variable `NL_MAX_WORKERS`). \
+In NeoLoad Web SaaS, the rate limit of 300 calls per minute may be reached, the CLI will adapt and slow down.
+
+To see which API calls are made, you can use the debug option: `neoload --debug report`
 
 ## View zones
 ```

--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -898,7 +898,12 @@ def get_elements_data(result_id, base_col, time_binding, include_points, statist
     procedure = lambda el: (
         get_perf_time(), get_element_data(el, result_id, time_binding, include_points, statistics_list, use_txn_raw))
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_ELEMENTS_WORKERS) as executor:
+    max_workers = MAX_ELEMENTS_WORKERS
+    try:
+        max_workers = int(os.getenv('NL_MAX_WORKERS', MAX_ELEMENTS_WORKERS))
+    except ValueError:
+        logging.warning(f'NL_MAX_WORKERS environment variable is not an integer. Use default {MAX_ELEMENTS_WORKERS}')
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         translate = {executor.submit(procedure, el): el for el in base_col}
         for future in concurrent.futures.as_completed(translate):
             orig = translate[future]


### PR DESCRIPTION
## What?
Ease the configuration of parallel requests made by the report command.

## Why?
Some customers encounter requests timeouts