### PR TITLE
fix report generation for results started from a French controller on Linux

### DIFF
--- a/neoload/neoload_cli_lib/rest_crud.py
+++ b/neoload/neoload_cli_lib/rest_crud.py
@@ -169,7 +169,7 @@ def __create_url(endpoint: str):
 
 
 def __handle_error(response):
-    response.encoding = 'ISO-8859-1'
+    response.encoding = response.apparent_encoding
     status_code = response.status_code
     if status_code > 299:
         request = response.request


### PR DESCRIPTION
Apparently, in some endpoints, NLW responses are UTF-8 encoded but no response header says it.
