### PR TITLE
fix report json with UTF-8 characters rendered as ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,14 @@ neoload wait cur
 
 [An example for Jenkins pipeline is found here.](examples/pipelines/jenkins/Jenkinsfile_slafails)
 
+## Troubleshooting
+### Windows and non UTF-8 characters
+Windows use default encoding as ASCII, but the NeoLoad CLI needs UTF-8 encoding.\
+Before running some commands like `neoload report` on windows, you need to set environment variable `set PYTHONUTF8=1`\
+More info [here](https://docs.python.org/3/using/windows.html#utf-8-mode) and [here](https://docs.python.org/3/library/os.html#utf8-mode).
+Note that with Python 3.15, no need to do that anymore [PEP 686 – Make UTF-8 mode default](https://peps.python.org/pep-0686/)
+
+
 ## Packaging the CLI with Build Agents
 Many of the above CI examples include a step to explicitly install the NeoLoad CLI as part of the
 build steps. However, if you want the CLI baked into some build agent directly so that it

--- a/neoload/commands/report.py
+++ b/neoload/commands/report.py
@@ -224,7 +224,7 @@ def parse_source_data_spec(json_in, model, report_type, name):
 
 def process_final_output(template, template_text, json_data):
     if template_text is None or template_text == "":
-        return json.dumps(json_data)
+        return json.dumps(json_data, ensure_ascii=False)
     else:
         dirname = os.path.dirname(os.path.abspath(template))
         loader = jinja2.FileSystemLoader(searchpath=dirname)


### PR DESCRIPTION
Also: document for Windows: encoding is default ISO-8859-1 but it is easier to make the the CLI expect always UTF-8 encoding. So the special chars are correctly rendered in the console output
