### PR TITLE
DEVOPS-843: Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 2
 
@@ -64,9 +64,9 @@ jobs:
         echo "merge_to_trunk: ${{ env.merge_to_trunk }}"
         echo "integration_moment: ${{ env.integration_moment }}"
         echo "docker_files_changed: ${{ env.docker_files_changed }}"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: "If-FullTesting: Pre-cache Images"
@@ -95,7 +95,7 @@ jobs:
         coverage3 combine
         coverage3 xml
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
+      uses: sonarsource/sonarcloud-github-action@ffc3010689be73b8e5ae0c57ce35968afd7909e8 # v5.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -103,7 +103,7 @@ jobs:
       if: failure()
       run: zip -r tests.zip tests/
     - name: Upload Test Folder on failure
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: failure()
       with:
         name: test-folder ${{ matrix.node-version }}

--- a/.github/workflows/python-post-release-changelog-pr.yml
+++ b/.github/workflows/python-post-release-changelog-pr.yml
@@ -14,7 +14,7 @@ jobs:
       new_branch_name: CHANGELOG-${{ github.event.inputs.tag }}
     #if: ${{ !contains(github.ref, 'rc') && !contains(github.ref, 'dev') }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         ref: refs/heads/master
@@ -30,7 +30,7 @@ jobs:
         git branch
         git status
 
-    - uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@bb6434c747fa7022e12fa1cae2a0951fcffcff26 # v1.253.0
       with:
         ruby-version: 3.2
     - name: Update Changelog for Dist
@@ -51,7 +51,7 @@ jobs:
         git log -n 5
         git push --set-upstream origin ${{ env.new_branch_name }}
     - name: pull-request
-      uses: repo-sync/pull-request@v2
+      uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1
       with:
         source_branch: "${{ env.new_branch_name }}"
         destination_branch: "master"
@@ -60,7 +60,7 @@ jobs:
         pr_draft: true
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Archive Changelog
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: CHANGELOG

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -9,9 +9,9 @@ jobs:
     if: ${{ github.event.base_ref == 'refs/heads/master' || contains(github.ref, '.dev') }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.x'
     - name: Prepare distribution
@@ -25,6 +25,6 @@ jobs:
         python setup.py sdist bdist_wheel
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@7f25271a4aa483500f742f9492b2ab5648d61011 # v1.12.4
       with:
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This PR updates GitHub Actions to use commit SHAs instead of tags or branches.

Updated files:
- .github/workflows/python-integration-tests.yml
- .github/workflows/python-package.yml
- .github/workflows/python-post-release-changelog-pr.yml
- .github/workflows/python-release.yml