### PR TITLE
Fix upload command. Don't remove the nlp file and don't print password even encrypted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ htmlcov/
 build/
 dist/
 neoload/version.py
+venv/
+.venv/

--- a/tests/commands/project/test_upload_with_password.py
+++ b/tests/commands/project/test_upload_with_password.py
@@ -1,58 +1,49 @@
-import pytest
+import os
 import zipfile
-from pathlib import Path
-from commands.project import extract_nlp_from_zip, find_password_in_nlp, upload
 
+from commands.project import has_password_in_zip_project, has_password_in_folder_project, upload
 
-@pytest.fixture
-def create_test_zip(tmp_path):
-    zip_path = tmp_path / "test.zip"
-    nlp_content = """project.name=test
+nlp_content_with_password = """project.name=test
 project.version=8.10
 project.password.hash=12vsXUgFbgL2g7u5aMuRsyhimKuEIk+jMXVD5pbkfo0=$0
 """
+nlp_content = """project.name=test
+project.version=8.10
+"""
+
+
+def create_neoload_project_zip(tmp_path, with_password):
+    zip_path = tmp_path / "test.zip"
     with zipfile.ZipFile(zip_path, 'w') as zipf:
-        zipf.writestr('test.nlp', nlp_content)
+        zipf.writestr('test.nlp', nlp_content_with_password if with_password else nlp_content)
     return zip_path
 
 
-def test_extract_nlp_from_zip(create_test_zip):
-    zip_path = create_test_zip
-    nlp_file = extract_nlp_from_zip(zip_path)
-    assert nlp_file is not None
-    assert nlp_file.name == 'test.nlp'
+def create_neoload_project_folder(tmp_path, with_password):
+    folder_path = tmp_path / "test_project"
+    if not folder_path.exists():
+        os.mkdir(folder_path)
+    with open(folder_path / "test.nlp", "w") as f:
+        f.write(nlp_content_with_password if with_password else nlp_content)
+    return folder_path
 
 
-def test_find_password_in_nlp(create_test_zip):
-    zip_path = create_test_zip
-    nlp_file = extract_nlp_from_zip(zip_path)
-    password = find_password_in_nlp(nlp_file)
-    assert password == "12vsXUgFbgL2g7u5aMuRsyhimKuEIk+jMXVD5pbkfo0=$0"
+def test_has_password_in_zip_project(tmp_path):
+    zip_with_password = create_neoload_project_zip(tmp_path, True)
+    assert has_password_in_zip_project(zip_with_password) == True
+    zip_project = create_neoload_project_zip(tmp_path, False)
+    assert has_password_in_zip_project(zip_project) == False
+
+
+def test_has_password_in_folder_project(tmp_path):
+    folder_with_password = create_neoload_project_folder(tmp_path, True)
+    assert has_password_in_folder_project(folder_with_password) == True
+    folder_project = create_neoload_project_folder(tmp_path, False)
+    assert has_password_in_folder_project(folder_project) == False
 
 
 def test_upload_with_password(mocker, tmp_path):
-    zip_path = tmp_path / "test.zip"
-    nlp_content = """project.name=test
-project.version=8.10
-project.password.hash=12vsXUgFbgL2g7u5aMuRjsyhimKuEIk+jMXVD5pbkfo0=$0
-"""
-    with zipfile.ZipFile(zip_path, 'w') as zipf:
-        zipf.writestr('test.nlp', nlp_content)
-
+    zip_with_password = create_neoload_project_zip(tmp_path, True)
     mock_upload_project = mocker.patch('commands.project.neoLoad_project.upload_project', return_value=9)
-    upload(zip_path, "test_id", "pathToSave/file.zip")
-    mock_upload_project.assert_called_once_with(zip_path, 'v2/tests/test_id/project', 'pathToSave/file.zip')
-
-
-def test_upload_password(mocker, tmp_path):
-    zip_path = tmp_path / "test.zip"
-    nlp_content = """project.name=test
-project.version=8.10
-project.password.hash=12vsXUgFbgL2g7u5aMuRsyhimKuEIk+jMXVD5pbkfo0=$0
-"""
-    with zipfile.ZipFile(zip_path, 'w') as zipf:
-        zipf.writestr('test.nlp', nlp_content)
-
-    mock_upload_project = mocker.patch('commands.project.neoLoad_project.upload_project', return_value=9)
-    upload(zip_path, "test_id", "pathToSave/file.zip")
-    mock_upload_project.assert_called_once_with(zip_path, 'v2/tests/test_id/project', 'pathToSave/file.zip')
+    upload(zip_with_password, "test_id", "pathToSave/file.zip")
+    mock_upload_project.assert_called_once_with(zip_with_password, 'v2/tests/test_id/project', 'pathToSave/file.zip')


### PR DESCRIPTION
## What?

- Bug fix: The nlp file was removed when uploading the project as a folder
- Change: do not display encrypted password. It will not be helpful for users and not great from security perspective
- Refactor code to simplify it (no need to retrieve the password string).
- Remover duplicated unit test and add unit test coverage