### PR TITLE
Fix changement of Docker API

### DIFF
--- a/neoload/neoload_cli_lib/docker_lib.py
+++ b/neoload/neoload_cli_lib/docker_lib.py
@@ -143,7 +143,14 @@ def compute_hosts(lg_containers):
     hosts = {}
     for lg_container in lg_containers:
         lg_container.reload()  # refresh data after launch.
-        hosts[lg_container.name] = lg_container.attrs['NetworkSettings'].get('IPAddress') or tools.find_attr('IPAddress', lg_container.attrs['NetworkSettings'])
+        ip_address = lg_container.attrs['NetworkSettings'].get('IPAddress') or tools.find_attr(
+            'IPAddress', lg_container.attrs['NetworkSettings']
+        )
+        if not ip_address:
+            raise cli_exception.CliException(
+                "no IPAddress found for container " + lg_container.name
+            )
+        hosts[lg_container.name] = ip_address
     return hosts
 
 

--- a/neoload/neoload_cli_lib/docker_lib.py
+++ b/neoload/neoload_cli_lib/docker_lib.py
@@ -143,7 +143,7 @@ def compute_hosts(lg_containers):
     hosts = {}
     for lg_container in lg_containers:
         lg_container.reload()  # refresh data after launch.
-        hosts[lg_container.name] = lg_container.attrs['NetworkSettings']['IPAddress']
+        hosts[lg_container.name] = lg_container.attrs['NetworkSettings'].get('IPAddress') or tools.find_attr('IPAddress', lg_container.attrs['NetworkSettings'])
     return hosts
 
 

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -34,6 +34,16 @@ __ci_env_var_signatures = {
 
 __batch = False
 
+def find_attr(key :str, adict :dict):
+    stack = [adict]
+    while stack:
+        d = stack.pop()
+        if key in d:
+            return d[key]
+        for k, v in d.items():
+            if isinstance(v, dict):
+                stack.append(v)
+    return None
 
 def compute_version():
     if __version__ is not None:

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -40,7 +40,7 @@ def find_attr(key :str, adict :dict):
         d = stack.pop()
         if key in d:
             return d[key]
-        for k, v in d.items():
+        for v in d.values():
             if isinstance(v, dict):
                 stack.append(v)
     return None

--- a/neoload/neoload_cli_lib/tools.py
+++ b/neoload/neoload_cli_lib/tools.py
@@ -34,7 +34,7 @@ __ci_env_var_signatures = {
 
 __batch = False
 
-def find_attr(key :str, adict :dict):
+def find_attr(key: str, adict: dict):
     stack = [adict]
     while stack:
         d = stack.pop()

--- a/tests/neoload_cli_lib/test_tools.py
+++ b/tests/neoload_cli_lib/test_tools.py
@@ -1,5 +1,5 @@
 import os
-from neoload.neoload_cli_lib.tools import string_to_bool_json
+from neoload.neoload_cli_lib.tools import string_to_bool_json, find_attr
 
 from neoload_cli_lib import tools
 
@@ -95,3 +95,9 @@ def test_string_to_boolean_json():
 
     for false_value in tools.get_false_values():
         assert string_to_bool_json(false_value) is False
+
+
+def test_find_attr1():
+    d = {'a':'f', 'b':{'c':'d','d':{'o':'r','e':'f','s':{'p','o'}},'g':'i'}}
+    assert find_attr('e',d) is 'f'
+    assert find_attr('z',d) is None

--- a/tests/neoload_cli_lib/test_tools.py
+++ b/tests/neoload_cli_lib/test_tools.py
@@ -97,7 +97,7 @@ def test_string_to_boolean_json():
         assert string_to_bool_json(false_value) is False
 
 
-def test_find_attr1():
+def test_find_attr_returns_nested_value_and_none_when_missing():
     d = {'a':'f', 'b':{'c':'d','d':{'o':'r','e':'f','s':{'p','o'}},'g':'i'}}
     assert find_attr('e',d) == 'f'
     assert find_attr('z',d) is None

--- a/tests/neoload_cli_lib/test_tools.py
+++ b/tests/neoload_cli_lib/test_tools.py
@@ -99,5 +99,5 @@ def test_string_to_boolean_json():
 
 def test_find_attr1():
     d = {'a':'f', 'b':{'c':'d','d':{'o':'r','e':'f','s':{'p','o'}},'g':'i'}}
-    assert find_attr('e',d) is 'f'
+    assert find_attr('e',d) == 'f'
     assert find_attr('z',d) is None


### PR DESCRIPTION
## What?
This is hotfix to continue to get IPAdress from LG docker container to configure correctly nlw. 

## Why?
With the new version of docker api IPAdress has moved on network -> bridge

## How?
I looking for inside all sub dictionary the IPAddress