### PR TITLE
LOAD-38517 — Draft-aware schema validation + ETag-based schema caching

### DIFF
--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -22,7 +22,8 @@ __default_schema_url = "https://raw.githubusercontent.com/Neotys-Labs/neoload-mo
 # several project files together (mirrors neoload-legacy's
 # ConfigurationManager.mergeAsCodeProject, which does the same plain
 # concatenation for a resolved "includes:" tree).
-_MERGED_ARRAY_FIELDS = ['sla_profiles', 'variables', 'servers', 'user_paths', 'populations', 'scenarios']
+_MERGED_ARRAY_FIELDS = ['sla_profiles', 'variables', 'servers', 'user_paths', 'populations', 'scenarios', 'frameworks']
+_MERGED_SPECIAL_FIELDS = set(_MERGED_ARRAY_FIELDS) | {'project_settings', 'name', 'includes'}
 
 
 def parse_yaml_file(file_path):
@@ -57,6 +58,14 @@ def merge_projects(projects):
     for project in projects:
         if project.get('name'):
             merged['name'] = project['name']
+
+    # Carry over any other/unrecognized top-level key too, so genuinely
+    # invalid content isn't silently dropped by the merge instead of being
+    # caught by the schema (e.g. root "additionalProperties: false").
+    for project in projects:
+        for key, value in project.items():
+            if key not in _MERGED_SPECIAL_FIELDS:
+                merged[key] = value
 
     return merged
 
@@ -161,11 +170,15 @@ def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
                 else:
                     raise err
 
-    if any_errs:
-        raise ValueError('One or more errors in files underneath this directory.')
-
+    # Validate the merged project (whatever was successfully parsed) before
+    # reporting per-file parse errors, so a schema-related failure (e.g. the
+    # schema itself being invalid) always surfaces on its own rather than
+    # being masked by unrelated parse errors elsewhere in the directory.
     merged_project = merge_projects(projects)
     validate_project_object(merged_project, schema_spec, ssl_cert, check_schema=True, label="directory %s" % path)
+
+    if any_errs:
+        raise ValueError('One or more errors in files underneath this directory.')
 
 
 def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -7,7 +7,7 @@ import yaml
 from yaml.scanner import ScannerError
 
 from neoload_cli_lib import cli_exception, bad_as_code_exception
-from neoload_cli_lib.user_data import update_schema, get_yaml_schema, tools
+from neoload_cli_lib.user_data import update_schema, get_yaml_schema, get_yaml_schema_etag, tools
 
 import logging
 import hashlib
@@ -17,6 +17,7 @@ from neoload_cli_lib.neoLoad_project import is_not_to_be_included
 
 YAML_NOT_CONFIRM_MESSAGE = "YAML does not confirm to NeoLoad DSL schema."
 __default_schema_url = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3/neoload-project/src/main/resources/as-code.latest.schema.json"
+
 
 def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
     json_schema = init_yaml_schema_with_checks(schema_spec,ssl_cert,check_schema)
@@ -38,7 +39,9 @@ def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
     except ScannerError as err:
         raise cli_exception.CliException('This is not a valid yaml file [{}] :\n{}'.format(yaml_file_path,err))
 
-    v = jsonschema.validators.Draft7Validator(schema_as_object)
+    validator_cls = jsonschema.validators.validator_for(schema_as_object, jsonschema.validators.Draft7Validator)
+    logging.debug("Using JSON-Schema validator: %s" % validator_cls.__name__)
+    v = validator_cls(schema_as_object)
     try:
         v.validate(yaml_as_object)
     except jsonschema.SchemaError as err:
@@ -90,35 +93,52 @@ def validate_yaml_dir_file(file_path,schema_spec,extensions,nl_ignore_matcher,an
 def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
     json_schema = get_yaml_schema(False)
     if json_schema is not None:
-        logging.info('Loaded schema from disk.')
+        cached_etag = get_yaml_schema_etag()
+        if cached_etag:
+            logging.info('Loaded schema and ETag from disk cache.')
+        else:
+            logging.info('Loaded schema from disk cache (no ETag).')
+        logging.debug("Cached schema %s chars, etag=%s" % (len(json_schema), cached_etag or "none"))
     else:
         logging.warning('No prior cached schema on disk.')
-
-    if json_schema is not None:
-        logging.debug("Cached schema %s" %len(json_schema))
 
     if not check_schema:
         return json_schema
 
-    # even if there is something local, try checking if it's different from remote
     schema_spec_remote = __default_schema_url
     if schema_spec is None: schema_spec = schema_spec_remote
-    logging.debug("Getting remote schema %s" %schema_spec)
-    json_schema_spec = get_json_schema_by_spec(schema_spec,ssl_cert)
-    if json_schema_spec is not None:
-        logging.debug("Retrieved remote schema %s" %len(json_schema_spec))
+    logging.debug("Checking schema source for changes %s" %schema_spec)
 
-    # compare cached to spec/remote
     try:
-        logging.info('Comparing cached schema to remote schema')
-        hash_disk = "" if json_schema is None else hashlib.sha256(json_schema.encode()).hexdigest()
-        hash_spec = "" if json_schema_spec is None else hashlib.sha256(json_schema_spec.encode()).hexdigest()
-        if hash_disk != hash_spec:
-            logging.info('Cached schema differs from source!')
-            json_schema = json_schema_spec
-            update_schema(json_schema_spec)
+        if is_network_spec(schema_spec):
+            cached_etag = get_yaml_schema_etag() if json_schema is not None else None
+            json_schema_spec, response_etag, not_modified = get_network_schema_by_spec(schema_spec, ssl_cert, cached_etag)
+            if not_modified:
+                logging.info('Remote schema unchanged since last download (ETag match) - using cached schema.')
+            elif json_schema_spec is not None:
+                logging.debug("Retrieved remote schema %s chars, etag=%s" % (len(json_schema_spec), response_etag or "none"))
+                if response_etag:
+                    logging.info('Cached schema and ETag updated from remote source.')
+                else:
+                    logging.info('Cached schema updated from remote source (no ETag).')
+                json_schema = json_schema_spec
+                update_schema(json_schema_spec, response_etag)
+            else:
+                json_schema = None
         else:
-            logging.info('No differences between cached and remote schema.')
+            json_schema_spec = get_json_schema_by_spec(schema_spec, ssl_cert)
+            if json_schema_spec is not None:
+                logging.debug("Retrieved remote schema %s" %len(json_schema_spec))
+
+            logging.info('Comparing cached schema to remote schema')
+            hash_disk = "" if json_schema is None else hashlib.sha256(json_schema.encode()).hexdigest()
+            hash_spec = "" if json_schema_spec is None else hashlib.sha256(json_schema_spec.encode()).hexdigest()
+            if hash_disk != hash_spec:
+                logging.info('Cached schema differs from source!')
+                json_schema = json_schema_spec
+                update_schema(json_schema_spec)
+            else:
+                logging.info('No differences between cached and remote schema.')
     except Exception as err:
         logging.warning('Could not update schema cache {}\n{}'.format(schema_spec,err))
 
@@ -128,6 +148,29 @@ def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
     return json_schema
 
 
+def is_network_spec(schema_spec):
+    return type(schema_spec).__name__ != 'LocalPath' and '://' in str(schema_spec)
+
+
+def get_network_schema_by_spec(schema_spec, ssl_cert, cached_etag=None):
+    headers = {'If-None-Match': cached_etag} if cached_etag else {}
+    if cached_etag:
+        logging.info('Checking for schema updates (ETag) from network source %s' % schema_spec)
+    else:
+        logging.info('Downloading schema from network source %s' % schema_spec)
+    try:
+        response = requests.get(schema_spec, headers=headers, verify=tools.ssl_cert_to_verify(ssl_cert))
+    except Exception as err:
+        logging.warning('Could not obtain source schema {}\n{}'.format(schema_spec, err))
+        return None, cached_etag, False
+
+    if response.status_code == 304:
+        return None, cached_etag, True
+
+    etag = response.headers.get('ETag')
+    return response.text, etag if isinstance(etag, str) else None, False
+
+
 def get_json_schema_by_spec(schema_spec, ssl_cert):
     json_schema_spec = None
 
@@ -135,11 +178,7 @@ def get_json_schema_by_spec(schema_spec, ssl_cert):
         schema_spec = schema_spec.strpath
 
     if '://' in schema_spec:
-        try:
-            logging.info('Getting remote schema from network source %s' % schema_spec)
-            json_schema_spec = requests.get(schema_spec, verify=tools.ssl_cert_to_verify(ssl_cert)).text
-        except Exception as err:
-            logging.warning('Could not obtain source schema {}\n{}'.format(schema_spec,err))
+        json_schema_spec, _etag, _not_modified = get_network_schema_by_spec(schema_spec, ssl_cert)
     else:
         # if user passed in a local file as the --schema-url (for local version testing purposes too)
         schema_spec = os.path.abspath(schema_spec)

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -79,22 +79,33 @@ def resolve_includes(entry_file_path, project_root=None, _visited=None):
         raise cli_exception.CliException('Infinite loop detected in includes for as code file: %s' % entry_file_path)
     _visited = _visited | {entry_file_path}
 
+    logging.debug("Loading as code file: %s" % entry_file_path)
     doc = parse_yaml_file(entry_file_path)
+    includes = doc.get('includes', [])
+    if includes:
+        logging.debug("%s declares %d include(s): %s" % (entry_file_path, len(includes), includes))
     resolved = []
-    for include in doc.get('includes', []):
+    for include in includes:
         include_path = include if os.path.isabs(include) else os.path.join(project_root, include)
         if not include_path.lower().endswith(('.yaml', '.yml', '.json')):
             raise cli_exception.CliException(
                 "The 'includes' field accepts only the following file extensions: 'yaml', 'yml' or 'json': %s" % include_path)
         if not os.path.exists(include_path):
             raise cli_exception.CliException('As code file not found: %s' % include_path)
+        logging.debug("Resolving include \"%s\" -> %s (referenced from %s)" % (include, include_path, entry_file_path))
         resolved.extend(resolve_includes(include_path, project_root, _visited))
     resolved.append(doc)
     return resolved
 
 
 def resolve_and_merge_project(entry_file_path):
-    return merge_projects(resolve_includes(entry_file_path))
+    resolved = resolve_includes(entry_file_path)
+    logging.debug("Resolved %d as code file(s) for %s: %s" % (
+        len(resolved), entry_file_path, [f.get('name', '<no name>') for f in resolved]))
+    merged = merge_projects(resolved)
+    counts = {field: len(merged[field]) for field in _MERGED_ARRAY_FIELDS if field in merged}
+    logging.debug("Merged project name=%s counts=%s" % (merged.get('name', '<no name>'), counts))
+    return merged
 
 
 def validate_project_object(project_object, schema_spec, ssl_cert='', check_schema=True, label=None):

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -18,8 +18,86 @@ from neoload_cli_lib.neoLoad_project import is_not_to_be_included
 YAML_NOT_CONFIRM_MESSAGE = "YAML does not confirm to NeoLoad DSL schema."
 __default_schema_url = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3/neoload-project/src/main/resources/as-code.latest.schema.json"
 
+# Array-valued top-level as-code properties that get concatenated when merging
+# several project files together (mirrors neoload-legacy's
+# ConfigurationManager.mergeAsCodeProject, which does the same plain
+# concatenation for a resolved "includes:" tree).
+_MERGED_ARRAY_FIELDS = ['sla_profiles', 'variables', 'servers', 'user_paths', 'populations', 'scenarios']
 
-def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
+
+def parse_yaml_file(file_path):
+    try:
+        yaml_content = open(file_path)
+    except Exception as err:
+        raise cli_exception.CliException('Unable to open file %s:\n%s' % (file_path, str(err)))
+
+    try:
+        yaml_as_object = yaml.load(yaml_content, yaml.FullLoader)
+        if yaml_as_object is None:
+            raise cli_exception.CliException('Empty file: ' + str(file_path))
+    except ScannerError as err:
+        raise cli_exception.CliException('This is not a valid yaml file [{}] :\n{}'.format(file_path, err))
+
+    return yaml_as_object
+
+
+def merge_projects(projects):
+    merged = {}
+    for field in _MERGED_ARRAY_FIELDS:
+        items = [item for project in projects for item in project.get(field, [])]
+        if items:
+            merged[field] = items
+
+    project_settings = {}
+    for project in projects:
+        project_settings.update(project.get('project_settings', {}))
+    if project_settings:
+        merged['project_settings'] = project_settings
+
+    for project in projects:
+        if project.get('name'):
+            merged['name'] = project['name']
+
+    return merged
+
+
+def resolve_includes(entry_file_path, project_root=None, _visited=None):
+    """Recursively resolve "includes:" starting from entry_file_path, mirroring
+    neoload-legacy's ConfigurationManager.parseAsCodeFile: include paths are
+    resolved relative to project_root (not to the including file's own
+    directory), only "yaml"/"yml"/"json" files are accepted, and a file
+    currently being resolved on the same branch cannot be included again
+    (infinite loop detection). Returns an ordered list of parsed dicts
+    (includes first, entry file last) ready for merge_projects()."""
+    entry_file_path = os.path.abspath(entry_file_path)
+    if project_root is None:
+        project_root = os.path.dirname(entry_file_path)
+    if _visited is None:
+        _visited = set()
+
+    if entry_file_path in _visited:
+        raise cli_exception.CliException('Infinite loop detected in includes for as code file: %s' % entry_file_path)
+    _visited = _visited | {entry_file_path}
+
+    doc = parse_yaml_file(entry_file_path)
+    resolved = []
+    for include in doc.get('includes', []):
+        include_path = include if os.path.isabs(include) else os.path.join(project_root, include)
+        if not include_path.lower().endswith(('.yaml', '.yml', '.json')):
+            raise cli_exception.CliException(
+                "The 'includes' field accepts only the following file extensions: 'yaml', 'yml' or 'json': %s" % include_path)
+        if not os.path.exists(include_path):
+            raise cli_exception.CliException('As code file not found: %s' % include_path)
+        resolved.extend(resolve_includes(include_path, project_root, _visited))
+    resolved.append(doc)
+    return resolved
+
+
+def resolve_and_merge_project(entry_file_path):
+    return merge_projects(resolve_includes(entry_file_path))
+
+
+def validate_project_object(project_object, schema_spec, ssl_cert='', check_schema=True, label=None):
     json_schema = init_yaml_schema_with_checks(schema_spec,ssl_cert,check_schema)
     try:
         schema_as_object = json.loads(json_schema)
@@ -27,67 +105,60 @@ def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
         raise bad_as_code_exception.BadAsCodeSchemaException(
             'This is not a valid json schema [{}] :\n{}'.format(schema_spec, err))
 
-    try:
-        yaml_content = open(yaml_file_path)
-    except Exception as err:
-        raise cli_exception.CliException('Unable to open file %s:\n%s' % (yaml_file_path, str(err)))
-
-    try:
-        yaml_as_object = yaml.load(yaml_content, yaml.FullLoader)
-        if yaml_as_object is None:
-            raise cli_exception.CliException('Empty file: ' + str(yaml_file_path))
-    except ScannerError as err:
-        raise cli_exception.CliException('This is not a valid yaml file [{}] :\n{}'.format(yaml_file_path,err))
-
     validator_cls = jsonschema.validators.validator_for(schema_as_object, jsonschema.validators.Draft7Validator)
     logging.debug("Using JSON-Schema validator: %s" % validator_cls.__name__)
     v = validator_cls(schema_as_object)
     try:
-        v.validate(yaml_as_object)
+        v.validate(project_object)
     except jsonschema.SchemaError as err:
         raise cli_exception.CliException('This is not a valid json schema:\n%s' % str(err))
     except jsonschema.ValidationError as err:
         msgs = ""
-        for error in sorted(v.iter_errors(yaml_as_object), key=str):
+        for error in sorted(v.iter_errors(project_object), key=str):
             path = "\\".join(list(map(lambda x: str(x), error.path)))
             msgs += "\n" + (error.message if hasattr(error, 'message') else str(error)) + "\n\tat: " + path + "\n\tgot: \n" + (yaml.dump(error.instance) if hasattr(error, 'instance') else '') + "\n"
-        msgs = ("in file %s" % yaml_file_path) + msgs
+        msgs = ("in %s" % label if label else "") + msgs
         raise cli_exception.CliException(YAML_NOT_CONFIRM_MESSAGE + '\n' + msgs)
+
+
+def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
+    # Resolve and merge "includes:" into one complete in-memory project before
+    # validating, instead of validating this file in isolation.
+    merged_project = resolve_and_merge_project(yaml_file_path)
+    validate_project_object(merged_project, schema_spec, ssl_cert, check_schema, label="file %s" % yaml_file_path)
 
 
 def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
     ignore_file = os.path.join(path, '.nlignore')
     nl_ignore_matcher =  gitignorefile.parse(ignore_file) if os.path.exists(ignore_file) else None
-    first_time_check = True
     extensions = ['yml','yaml','json']
+
+    # Merge every yaml/yml/json project file found under the directory into a
+    # single in-memory project, then validate that merged project once -
+    # instead of validating each file (including included fragments that are
+    # never meant to be a complete project on their own) in isolation.
+    projects = []
     any_errs = False
     for root, dirs, files in os.walk(path):
         for file in files:
             file_path = os.path.join(root, file)
-            (any_errs,first_time_check) = validate_yaml_dir_file(file_path,schema_spec,extensions,nl_ignore_matcher,any_errs,first_time_check,continue_on_error,ssl_cert)
+            if not any(file_path.endswith("." + ext) for ext in extensions) or is_not_to_be_included(file_path, nl_ignore_matcher):
+                continue
+            logging.debug("file_path: {}".format(file_path))
+            try:
+                projects.append(parse_yaml_file(file_path))
+            except Exception as err:
+                any_errs = True
+                if continue_on_error:
+                    logging.error(str(err) + "\n")
+                else:
+                    raise err
 
     if any_errs:
         raise ValueError('One or more errors in files underneath this directory.')
 
-def validate_yaml_dir_file(file_path,schema_spec,extensions,nl_ignore_matcher,any_errs,first_time_check,continue_on_error,ssl_cert):
-
-    if any(filter(lambda ext,file_path=file_path: file_path.endswith("."+ext),extensions)) and \
-       not is_not_to_be_included(file_path, nl_ignore_matcher):
-        logging.debug("file_path: {}".format(file_path))
-        try:
-            validate_yaml(file_path, schema_spec, ssl_cert, check_schema=first_time_check)
-        except ValueError as err:
-            any_errs = True
-            logging.error("INFOMSG:%s" % str(err))
-        except Exception as err:
-            any_errs = True
-            if continue_on_error and not isinstance(err, bad_as_code_exception.BadAsCodeSchemaException):
-                logging.error(str(err) + "\n")
-            else:
-                raise err
-        first_time_check = False
-
-    return (any_errs,first_time_check)
+    merged_project = merge_projects(projects)
+    validate_project_object(merged_project, schema_spec, ssl_cert, check_schema=True, label="directory %s" % path)
 
 
 def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -66,16 +66,26 @@ def merge_projects(projects):
     return merged
 
 
-def resolve_includes(entry_file_path, project_root=None, _visited=None, _paths=None):
+def resolve_includes(entry_file_path, project_root=None, _ancestors=None, _paths=None, _resolved_once=None):
     entry_file_path = os.path.abspath(entry_file_path)
     if project_root is None:
         project_root = os.path.dirname(entry_file_path)
-    if _visited is None:
-        _visited = set()
+    # Files already pulled into this resolution, shared across the whole
+    # include tree: a file reachable through several different branches
+    # (a -> b -> d and a -> c -> d) must contribute its content exactly once.
+    if _resolved_once is None:
+        _resolved_once = set()
+    # Chain of files currently being resolved, i.e. only this branch's
+    # ancestors - so a file being reachable twice is fine, while a file
+    # including one of its own ancestors is a real cycle.
+    if _ancestors is None:
+        _ancestors = frozenset()
 
-    if entry_file_path in _visited:
+    if entry_file_path in _ancestors:
         raise cli_exception.CliException('Infinite loop detected in includes for as code file: %s' % entry_file_path)
-    _visited = _visited | {entry_file_path}
+    if entry_file_path in _resolved_once:
+        return []
+    _resolved_once.add(entry_file_path)
 
     doc = parse_yaml_file(entry_file_path)
     resolved = []
@@ -86,7 +96,8 @@ def resolve_includes(entry_file_path, project_root=None, _visited=None, _paths=N
                 "The 'includes' field accepts only the following file extensions: 'yaml' or 'yml': %s" % include_path)
         if not os.path.exists(include_path):
             raise cli_exception.CliException('As code file not found: %s' % include_path)
-        resolved.extend(resolve_includes(include_path, project_root, _visited, _paths))
+        resolved.extend(resolve_includes(include_path, project_root, _ancestors | {entry_file_path}, _paths,
+                                        _resolved_once))
     resolved.append(doc)
     if _paths is not None:
         _paths.append(entry_file_path)

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -149,33 +149,60 @@ def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
     nl_ignore_matcher =  gitignorefile.parse(ignore_file) if os.path.exists(ignore_file) else None
     extensions = ['yml','yaml','json']
 
-    # Merge every yaml/yml/json project file found under the directory into a
-    # single in-memory project, then validate that merged project once -
-    # instead of validating each file (including included fragments that are
-    # never meant to be a complete project on their own) in isolation.
-    projects = []
-    any_errs = False
+    all_files = []
     for root, dirs, files in os.walk(path):
+        # Never descend into hidden directories (.git, .github, .idea, ...) -
+        # they're tooling/CI config, never as-code project content.
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
         for file in files:
-            file_path = os.path.join(root, file)
-            if not any(file_path.endswith("." + ext) for ext in extensions) or is_not_to_be_included(file_path, nl_ignore_matcher):
-                continue
-            logging.debug("file_path: {}".format(file_path))
-            try:
-                projects.append(parse_yaml_file(file_path))
-            except Exception as err:
-                any_errs = True
-                if continue_on_error:
-                    logging.error(str(err) + "\n")
-                else:
-                    raise err
+            file_path = os.path.abspath(os.path.join(root, file))
+            if any(file_path.endswith("." + ext) for ext in extensions) and not is_not_to_be_included(file_path, nl_ignore_matcher):
+                all_files.append(file_path)
 
-    # Validate the merged project (whatever was successfully parsed) before
-    # reporting per-file parse errors, so a schema-related failure (e.g. the
-    # schema itself being invalid) always surfaces on its own rather than
-    # being masked by unrelated parse errors elsewhere in the directory.
-    merged_project = merge_projects(projects)
-    validate_project_object(merged_project, schema_spec, ssl_cert, check_schema=True, label="directory %s" % path)
+    for file_path in all_files:
+        logging.debug("file_path: {}".format(file_path))
+
+    # A file is a fragment (not a standalone root project) if it gets pulled
+    # in by another file's "includes:" tree. The only correct way to tell is
+    # to actually resolve includes from every candidate as if it were a root -
+    # "includes:" paths are always relative to the resolving entry file's own
+    # directory (matching resolve_includes()/neoload-legacy semantics), not
+    # necessarily the fragment's own directory, so a nested fragment's own
+    # "includes:" can only be followed correctly from its true root. Whatever
+    # a candidate's resolution successfully sweeps in is marked as referenced;
+    # candidates that fail to resolve on their own (e.g. because they're a
+    # fragment whose includes only make sense from an ancestor's directory)
+    # simply contribute nothing here - any genuine parse/include errors still
+    # surface later when the real root is validated.
+    referenced = set()
+    any_errs = False
+    for file_path in all_files:
+        try:
+            resolved_paths = []
+            resolve_includes(file_path, _paths=resolved_paths)
+        except cli_exception.CliException:
+            continue
+        referenced.update(p for p in resolved_paths if p != file_path)
+
+    root_files = sorted(f for f in all_files if f not in referenced)
+
+    if not root_files:
+        raise cli_exception.CliException(
+            'No root as-code project file found underneath %s (every yaml/yml/json file found is referenced as an include).' % path)
+
+    for file_path in root_files:
+        logging.debug("Validating root project file: %s" % file_path)
+        try:
+            validate_yaml(file_path, schema_spec, ssl_cert, check_schema=True)
+        except Exception as err:
+            any_errs = True
+            # A schema-related failure always aborts immediately with its own
+            # message, instead of being logged-and-continued like a regular
+            # per-project validation failure.
+            if continue_on_error and not isinstance(err, bad_as_code_exception.BadAsCodeSchemaException):
+                logging.error(str(err) + "\n")
+            else:
+                raise err
 
     if any_errs:
         raise ValueError('One or more errors in files underneath this directory.')

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -61,14 +61,15 @@ def merge_projects(projects):
     return merged
 
 
-def resolve_includes(entry_file_path, project_root=None, _visited=None):
+def resolve_includes(entry_file_path, project_root=None, _visited=None, _paths=None):
     """Recursively resolve "includes:" starting from entry_file_path, mirroring
     neoload-legacy's ConfigurationManager.parseAsCodeFile: include paths are
     resolved relative to project_root (not to the including file's own
     directory), only "yaml"/"yml"/"json" files are accepted, and a file
     currently being resolved on the same branch cannot be included again
     (infinite loop detection). Returns an ordered list of parsed dicts
-    (includes first, entry file last) ready for merge_projects()."""
+    (includes first, entry file last) ready for merge_projects(). When _paths
+    is provided, every resolved file path is appended to it in the same order."""
     entry_file_path = os.path.abspath(entry_file_path)
     if project_root is None:
         project_root = os.path.dirname(entry_file_path)
@@ -79,33 +80,28 @@ def resolve_includes(entry_file_path, project_root=None, _visited=None):
         raise cli_exception.CliException('Infinite loop detected in includes for as code file: %s' % entry_file_path)
     _visited = _visited | {entry_file_path}
 
-    logging.debug("Loading as code file: %s" % entry_file_path)
     doc = parse_yaml_file(entry_file_path)
-    includes = doc.get('includes', [])
-    if includes:
-        logging.debug("%s declares %d include(s): %s" % (entry_file_path, len(includes), includes))
     resolved = []
-    for include in includes:
+    for include in doc.get('includes', []):
         include_path = include if os.path.isabs(include) else os.path.join(project_root, include)
         if not include_path.lower().endswith(('.yaml', '.yml', '.json')):
             raise cli_exception.CliException(
                 "The 'includes' field accepts only the following file extensions: 'yaml', 'yml' or 'json': %s" % include_path)
         if not os.path.exists(include_path):
             raise cli_exception.CliException('As code file not found: %s' % include_path)
-        logging.debug("Resolving include \"%s\" -> %s (referenced from %s)" % (include, include_path, entry_file_path))
-        resolved.extend(resolve_includes(include_path, project_root, _visited))
+        resolved.extend(resolve_includes(include_path, project_root, _visited, _paths))
     resolved.append(doc)
+    if _paths is not None:
+        _paths.append(entry_file_path)
     return resolved
 
 
 def resolve_and_merge_project(entry_file_path):
-    resolved = resolve_includes(entry_file_path)
-    logging.debug("Resolved %d as code file(s) for %s: %s" % (
-        len(resolved), entry_file_path, [f.get('name', '<no name>') for f in resolved]))
-    merged = merge_projects(resolved)
-    counts = {field: len(merged[field]) for field in _MERGED_ARRAY_FIELDS if field in merged}
-    logging.debug("Merged project name=%s counts=%s" % (merged.get('name', '<no name>'), counts))
-    return merged
+    paths = []
+    resolved = resolve_includes(entry_file_path, _paths=paths)
+    logging.debug("Resolved includes for %s:\n%s" % (
+        entry_file_path, "\n".join("  - %s" % p for p in paths)))
+    return merge_projects(resolved)
 
 
 def validate_project_object(project_object, schema_spec, ssl_cert='', check_schema=True, label=None):

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -18,10 +18,6 @@ from neoload_cli_lib.neoLoad_project import is_not_to_be_included
 YAML_NOT_CONFIRM_MESSAGE = "YAML does not confirm to NeoLoad DSL schema."
 __default_schema_url = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3/neoload-project/src/main/resources/as-code.latest.schema.json"
 
-# Array-valued top-level as-code properties that get concatenated when merging
-# several project files together (mirrors neoload-legacy's
-# ConfigurationManager.mergeAsCodeProject, which does the same plain
-# concatenation for a resolved "includes:" tree).
 _MERGED_ARRAY_FIELDS = ['sla_profiles', 'variables', 'servers', 'user_paths', 'populations', 'scenarios', 'frameworks']
 _MERGED_SPECIAL_FIELDS = set(_MERGED_ARRAY_FIELDS) | {'project_settings', 'name', 'includes'}
 
@@ -71,14 +67,6 @@ def merge_projects(projects):
 
 
 def resolve_includes(entry_file_path, project_root=None, _visited=None, _paths=None):
-    """Recursively resolve "includes:" starting from entry_file_path, mirroring
-    neoload-legacy's ConfigurationManager.parseAsCodeFile: include paths are
-    resolved relative to project_root (not to the including file's own
-    directory), only "yaml"/"yml"/"json" files are accepted, and a file
-    currently being resolved on the same branch cannot be included again
-    (infinite loop detection). Returns an ordered list of parsed dicts
-    (includes first, entry file last) ready for merge_projects(). When _paths
-    is provided, every resolved file path is appended to it in the same order."""
     entry_file_path = os.path.abspath(entry_file_path)
     if project_root is None:
         project_root = os.path.dirname(entry_file_path)
@@ -93,9 +81,9 @@ def resolve_includes(entry_file_path, project_root=None, _visited=None, _paths=N
     resolved = []
     for include in doc.get('includes', []):
         include_path = include if os.path.isabs(include) else os.path.join(project_root, include)
-        if not include_path.lower().endswith(('.yaml', '.yml', '.json')):
+        if not include_path.lower().endswith(('.yaml', '.yml')):
             raise cli_exception.CliException(
-                "The 'includes' field accepts only the following file extensions: 'yaml', 'yml' or 'json': %s" % include_path)
+                "The 'includes' field accepts only the following file extensions: 'yaml' or 'yml': %s" % include_path)
         if not os.path.exists(include_path):
             raise cli_exception.CliException('As code file not found: %s' % include_path)
         resolved.extend(resolve_includes(include_path, project_root, _visited, _paths))
@@ -147,7 +135,7 @@ def validate_yaml(yaml_file_path, schema_spec, ssl_cert='', check_schema=True):
 def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
     ignore_file = os.path.join(path, '.nlignore')
     nl_ignore_matcher =  gitignorefile.parse(ignore_file) if os.path.exists(ignore_file) else None
-    extensions = ['yml','yaml','json']
+    extensions = ['yml','yaml']
 
     all_files = []
     for root, dirs, files in os.walk(path):

--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -16,6 +16,7 @@ __config_dir = appdirs.user_data_dir(__conf_name, __author, __version)
 __local_file = ".neoload_cli.yaml"
 CONFIG_FILE = __local_file if os.path.exists(__local_file) else os.path.join(__config_dir, "config.yaml")
 __yaml_schema_file = os.path.join(__config_dir, "yaml_schema.json")
+__yaml_schema_etag_file = os.path.join(__config_dir, "yaml_schema.etag")
 
 __no_write = False
 
@@ -245,7 +246,15 @@ def __load_yaml_schema():
     return None
 
 
+def __load_yaml_schema_etag():
+    if os.path.exists(__yaml_schema_etag_file):
+        with open(__yaml_schema_etag_file, "r") as stream:
+            return stream.read() or None
+    return None
+
+
 __yaml_schema_singleton = __load_yaml_schema()
+__yaml_schema_etag_singleton = __load_yaml_schema_etag()
 
 
 def get_yaml_schema(throw=True):
@@ -254,9 +263,20 @@ def get_yaml_schema(throw=True):
     return __yaml_schema_singleton
 
 
-def update_schema(yaml_schema_as_json: str):
-    global __yaml_schema_singleton
+def get_yaml_schema_etag():
+    return __yaml_schema_etag_singleton
+
+
+def update_schema(yaml_schema_as_json: str, etag: str = None):
+    global __yaml_schema_singleton, __yaml_schema_etag_singleton
     __yaml_schema_singleton = yaml_schema_as_json
+    __yaml_schema_etag_singleton = etag
     os.makedirs(__config_dir, exist_ok=True)
     with open(__yaml_schema_file, "w") as stream:
         stream.write(__yaml_schema_singleton)
+    if etag:
+        with open(__yaml_schema_etag_file, "w") as stream:
+            stream.write(etag)
+    elif os.path.exists(__yaml_schema_etag_file):
+        # no etag for this schema source (e.g. a local file) - don't leave a stale one around
+        os.remove(__yaml_schema_etag_file)

--- a/tests/commands/report/conftest.py
+++ b/tests/commands/report/conftest.py
@@ -1,0 +1,17 @@
+import glob
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def cleanup_actual_report_files():
+    """Report tests write their generated output straight into
+    tests/resources/report/ (actual_*, raw_actual_*) to compare it against the
+    checked-in expected_*/raw_expected_* fixtures. Remove those generated
+    files after each test, pass or fail, so they don't linger as untracked
+    files on disk."""
+    yield
+    for pattern in ('tests/resources/report/actual_*', 'tests/resources/report/raw_actual_*'):
+        for path in glob.glob(pattern):
+            os.remove(path)

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -44,11 +44,11 @@ class TestValidate:
         return result
 
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     def test_success(self, datafiles):
         self.try_success(datafiles / 'default.yaml')
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     def test_no_refresh(self, datafiles):
         file_path = datafiles / 'default.yaml'
         runner = CliRunner()
@@ -64,7 +64,7 @@ class TestValidate:
         assert schema_validation.YAML_NOT_CONFIRM_MESSAGE in str(result.output)
         assert result.exit_code == 1
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     @mock.patch('requests.get', mock.Mock(return_value=mock.Mock(text="<!DOCTYPE html><html>invalid resource</html>")))
     def test_bad_schema(self, datafiles):
         file_path = datafiles / 'default.yaml'
@@ -80,7 +80,7 @@ class TestValidate:
         assert re.compile(".*Error: Missing argument [\"']FILE[\"'].*", re.DOTALL).match(result.output) is not None
         assert result.exit_code == 2
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     @mock.patch('requests.get', mock.Mock(side_effect=Exception("Failed to establish a new connection")))
     def test_bad_schema_url(self, datafiles):
         file_path = datafiles / 'default.yaml'
@@ -102,7 +102,7 @@ class TestValidate:
         return runner.invoke(validate, [str(path), '--schema-url', url, '--refresh'])
 
     @pytest.mark.slow
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     def test_single_with_no_prior_schema(self, datafiles):
         (l, r) = self.preserve_schema()
 
@@ -120,7 +120,7 @@ class TestValidate:
 
     @pytest.mark.slow
     @pytest.mark.datafiles(
-        'tests/neoload_projects/example_1/default.yaml',
+        'tests/neoload_projects/example_1',
         'resources/as-code.latest.schema.json'
     )
     def test_single_with_prior_schema(self, datafiles):

--- a/tests/neoload_cli_lib/test_SchemaValidation.py
+++ b/tests/neoload_cli_lib/test_SchemaValidation.py
@@ -6,7 +6,7 @@ import neoload_cli_lib.schema_validation as schema_validation
 @pytest.mark.validation
 class TestSchemaValidation:
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     def test_success(self, datafiles):
         yaml_file_path = datafiles / 'default.yaml'
         schema_validation.validate_yaml(yaml_file_path, __schema_url__)

--- a/tests/neoload_cli_lib/test_etag_caching.py
+++ b/tests/neoload_cli_lib/test_etag_caching.py
@@ -1,0 +1,59 @@
+from unittest import mock
+
+import pytest
+
+import neoload_cli_lib.schema_validation as schema_validation
+
+
+@pytest.mark.validation
+class TestEtagCaching:
+
+    def test_sends_if_none_match_header_when_etag_cached(self):
+        mock_response = mock.Mock(status_code=304)
+        with mock.patch('requests.get', return_value=mock_response) as mock_get:
+            content, etag, not_modified = schema_validation.get_network_schema_by_spec(
+                "https://example.com/schema.json", ssl_cert='', cached_etag='"abc123"')
+
+        assert mock_get.call_args.kwargs['headers'] == {'If-None-Match': '"abc123"'}
+        assert not_modified is True
+        assert content is None
+        assert etag == '"abc123"'
+
+    def test_no_if_none_match_header_without_a_cached_etag(self):
+        mock_response = mock.Mock(status_code=200, text='{}')
+        mock_response.headers.get.return_value = None
+        with mock.patch('requests.get', return_value=mock_response) as mock_get:
+            schema_validation.get_network_schema_by_spec(
+                "https://example.com/schema.json", ssl_cert='', cached_etag=None)
+
+        assert mock_get.call_args.kwargs['headers'] == {}
+
+    def test_returns_new_content_and_etag_on_200(self):
+        mock_response = mock.Mock(status_code=200, text='{"type":"object"}')
+        mock_response.headers.get.return_value = '"new-etag"'
+        with mock.patch('requests.get', return_value=mock_response):
+            content, etag, not_modified = schema_validation.get_network_schema_by_spec(
+                "https://example.com/schema.json", ssl_cert='', cached_etag=None)
+
+        assert not_modified is False
+        assert content == '{"type":"object"}'
+        assert etag == '"new-etag"'
+
+    def test_non_string_etag_header_is_ignored(self):
+        # A misbehaving/mocked response whose .headers.get('ETag') doesn't
+        # return a real string must not be persisted as if it were one.
+        mock_response = mock.Mock(status_code=200, text='{}')
+        with mock.patch('requests.get', return_value=mock_response):
+            _content, etag, _not_modified = schema_validation.get_network_schema_by_spec(
+                "https://example.com/schema.json", ssl_cert='', cached_etag=None)
+
+        assert etag is None
+
+    def test_network_failure_keeps_cached_etag_and_returns_no_content(self):
+        with mock.patch('requests.get', side_effect=Exception("boom")):
+            content, etag, not_modified = schema_validation.get_network_schema_by_spec(
+                "https://example.com/schema.json", ssl_cert='', cached_etag='"abc"')
+
+        assert content is None
+        assert not_modified is False
+        assert etag == '"abc"'

--- a/tests/neoload_cli_lib/test_include_resolution.py
+++ b/tests/neoload_cli_lib/test_include_resolution.py
@@ -1,0 +1,76 @@
+import pytest
+
+import neoload_cli_lib.schema_validation as schema_validation
+from neoload_cli_lib import cli_exception
+
+
+@pytest.mark.validation
+class TestResolveIncludes:
+
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
+    def test_resolves_and_merges_real_includes(self, datafiles):
+        merged = schema_validation.resolve_and_merge_project(datafiles / 'default.yaml')
+        assert merged['name'] == 'NeoLoad-CLI-example-2_0'
+        # user_paths comes only from the included paths/geosearch_get.yaml file
+        assert [up['name'] for up in merged['user_paths']] == ['ex_2_0_geosearch_get']
+        # arrays declared directly in default.yaml are still present
+        assert merged['servers'][0]['name'] == 'geolookup_host'
+        assert merged['sla_profiles'][0]['name'] == 'geo_3rdparty_sla'
+
+    @pytest.mark.datafiles('tests/neoload_projects/circular_includes')
+    def test_detects_infinite_loop(self, datafiles):
+        with pytest.raises(cli_exception.CliException) as context:
+            schema_validation.resolve_and_merge_project(datafiles / 'a.yaml')
+        assert 'Infinite loop' in str(context.value)
+
+    def test_rejects_non_yaml_include(self, tmp_path):
+        (tmp_path / 'notes.txt').write_text('not a project file')
+        entry = tmp_path / 'entry.yaml'
+        entry.write_text('name: bad-include\nincludes:\n  - notes.txt\n')
+
+        with pytest.raises(cli_exception.CliException) as context:
+            schema_validation.resolve_and_merge_project(entry)
+        assert "'includes' field accepts only" in str(context.value)
+
+    def test_missing_include_file(self, tmp_path):
+        entry = tmp_path / 'entry.yaml'
+        entry.write_text('name: missing-include\nincludes:\n  - does_not_exist.yaml\n')
+
+        with pytest.raises(cli_exception.CliException) as context:
+            schema_validation.resolve_and_merge_project(entry)
+        assert 'As code file not found' in str(context.value)
+
+
+@pytest.mark.validation
+class TestMergeProjects:
+
+    def test_concatenates_array_fields_in_order(self):
+        merged = schema_validation.merge_projects([
+            {'variables': [{'constant': {'name': 'a'}}]},
+            {'variables': [{'constant': {'name': 'b'}}]},
+        ])
+        assert merged['variables'] == [{'constant': {'name': 'a'}}, {'constant': {'name': 'b'}}]
+
+    def test_last_non_empty_name_wins(self):
+        merged = schema_validation.merge_projects([
+            {'name': 'included-fragment'},
+            {'name': 'root-project'},
+        ])
+        assert merged['name'] == 'root-project'
+
+    def test_merges_project_settings_across_files(self):
+        merged = schema_validation.merge_projects([
+            {'project_settings': {'dynatrace.enabled': True}},
+            {'project_settings': {'qtest.enabled': True}},
+        ])
+        assert merged['project_settings'] == {'dynatrace.enabled': True, 'qtest.enabled': True}
+
+    def test_preserves_unrecognized_top_level_keys(self):
+        # A merge must not silently drop keys it doesn't know about - otherwise
+        # invalid/unexpected content becomes invisible to schema validation
+        # after the merge instead of being caught by e.g. root
+        # "additionalProperties: false".
+        merged = schema_validation.merge_projects([
+            {'name': 'p', 'totally_unexpected_key': 'oops'},
+        ])
+        assert merged['totally_unexpected_key'] == 'oops'

--- a/tests/neoload_cli_lib/test_include_resolution.py
+++ b/tests/neoload_cli_lib/test_include_resolution.py
@@ -1,7 +1,19 @@
+import json
+
 import pytest
 
 import neoload_cli_lib.schema_validation as schema_validation
 from neoload_cli_lib import cli_exception
+
+_MINIMAL_SCHEMA = {
+    "type": "object",
+    "required": ["name"],
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string"},
+        "servers": {"type": "array"},
+    },
+}
 
 
 @pytest.mark.validation
@@ -74,3 +86,94 @@ class TestMergeProjects:
             {'name': 'p', 'totally_unexpected_key': 'oops'},
         ])
         assert merged['totally_unexpected_key'] == 'oops'
+
+
+@pytest.mark.validation
+class TestValidateYamlDir:
+
+    def test_ignores_hidden_directories(self, tmp_path):
+        schema_path = tmp_path / 'schema.json'
+        schema_path.write_text(json.dumps(_MINIMAL_SCHEMA))
+        projects_dir = tmp_path / 'projects'
+        projects_dir.mkdir()
+        (projects_dir / 'project.yaml').write_text('name: my-project\n')
+
+        # A GitHub Actions workflow (or any other tooling/CI yaml) sitting in
+        # a hidden directory must never be picked up as a project file.
+        workflows_dir = projects_dir / '.github' / 'workflows'
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / 'ci.yml').write_text('name: CI\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n')
+
+        # Must not raise: the only real project file is valid, and .github/
+        # is never descended into.
+        schema_validation.validate_yaml_dir(str(projects_dir), str(schema_path))
+
+    def test_validates_independent_root_projects_separately(self, tmp_path):
+        # Keep the schema file itself outside the directory being validated -
+        # otherwise the directory walk would pick it up as just another
+        # ".json" file to validate as a project.
+        schema_path = tmp_path / 'schema.json'
+        schema_path.write_text(json.dumps(_MINIMAL_SCHEMA))
+        projects_dir = tmp_path / 'projects'
+        projects_dir.mkdir()
+
+        # project-a: a root file with an included fragment - the fragment
+        # must NOT be validated as if it were a complete project on its own.
+        project_a = projects_dir / 'project-a'
+        project_a.mkdir()
+        (project_a / 'root.yaml').write_text('name: project-a\nincludes:\n  - fragment.yaml\n')
+        (project_a / 'fragment.yaml').write_text('servers:\n  - name: s1\n')
+
+        # project-b: a second, entirely independent root project.
+        project_b = projects_dir / 'project-b'
+        project_b.mkdir()
+        (project_b / 'root.yaml').write_text('name: project-b\n')
+
+        # Must not raise: both roots are independently valid.
+        schema_validation.validate_yaml_dir(str(projects_dir), str(schema_path))
+
+    def test_a_failing_root_does_not_block_reporting_on_the_others(self, tmp_path):
+        schema_path = tmp_path / 'schema.json'
+        schema_path.write_text(json.dumps(_MINIMAL_SCHEMA))
+        projects_dir = tmp_path / 'projects'
+        projects_dir.mkdir()
+
+        (projects_dir / 'good.yaml').write_text('name: good-project\n')
+        (projects_dir / 'bad.yaml').write_text('not_name: bad-project\n')
+
+        with pytest.raises(ValueError, match='One or more errors'):
+            schema_validation.validate_yaml_dir(str(projects_dir), str(schema_path))
+
+    def test_no_root_found_in_empty_directory(self, tmp_path):
+        empty_dir = tmp_path / 'empty'
+        empty_dir.mkdir()
+
+        with pytest.raises(cli_exception.CliException, match='No root as-code project file found'):
+            schema_validation.validate_yaml_dir(str(empty_dir), str(tmp_path / 'unused-schema.json'))
+
+    def test_mutually_circular_includes_each_report_their_own_error(self, tmp_path):
+        # Neither file can be resolved as a root (each loops back into the
+        # other), so both remain candidates and each surfaces its own
+        # "infinite loop" error instead of one vague "no root found" message.
+        (tmp_path / 'a.yaml').write_text('name: a\nincludes:\n  - b.yaml\n')
+        (tmp_path / 'b.yaml').write_text('name: b\nincludes:\n  - a.yaml\n')
+
+        with pytest.raises(ValueError, match='One or more errors'):
+            schema_validation.validate_yaml_dir(str(tmp_path), str(tmp_path / 'unused-schema.json'))
+
+    def test_nested_fragment_include_resolves_relative_to_true_root(self, tmp_path):
+        # A fragment's own "includes:" is resolved relative to the true
+        # root's directory (matching resolve_includes() semantics), not the
+        # fragment's own directory - so it must still be recognized as a
+        # fragment, and its own nested include must not become a spurious
+        # root either.
+        schema_path = tmp_path / 'schema.json'
+        schema_path.write_text(json.dumps(_MINIMAL_SCHEMA))
+        project_dir = tmp_path / 'project'
+        (project_dir / 'sub').mkdir(parents=True)
+        (project_dir / 'root.yaml').write_text('name: p\nincludes:\n  - sub/fragment.yaml\n')
+        (project_dir / 'sub' / 'fragment.yaml').write_text('includes:\n  - sub/extra.yaml\n')
+        (project_dir / 'sub' / 'extra.yaml').write_text('servers:\n  - name: s1\n')
+
+        # Must not raise, and must only treat root.yaml as a root project.
+        schema_validation.validate_yaml_dir(str(project_dir), str(schema_path))

--- a/tests/neoload_cli_lib/test_include_resolution.py
+++ b/tests/neoload_cli_lib/test_include_resolution.py
@@ -35,6 +35,30 @@ class TestResolveIncludes:
             schema_validation.resolve_and_merge_project(datafiles / 'a.yaml')
         assert 'Infinite loop' in str(context.value)
 
+    def test_shared_include_is_merged_only_once(self, tmp_path):
+        # Diamond: a includes b and c, and both include d. That is not a
+        # cycle, so it must resolve - and d's content must appear exactly once
+        # in the merged project.
+        (tmp_path / 'a.yaml').write_text('name: a\nincludes:\n  - b.yaml\n  - c.yaml\n')
+        (tmp_path / 'b.yaml').write_text('includes:\n  - d.yaml\nservers:\n  - name: from_b\n')
+        (tmp_path / 'c.yaml').write_text('includes:\n  - d.yaml\nservers:\n  - name: from_c\n')
+        (tmp_path / 'd.yaml').write_text('servers:\n  - name: from_d\n')
+
+        merged = schema_validation.resolve_and_merge_project(tmp_path / 'a.yaml')
+        assert [server['name'] for server in merged['servers']] == ['from_d', 'from_b', 'from_c']
+
+    def test_detects_cycle_below_a_shared_include(self, tmp_path):
+        # Same diamond, but d includes c back: that closes a real cycle
+        # (c -> d -> c) and must still be reported.
+        (tmp_path / 'a.yaml').write_text('name: a\nincludes:\n  - b.yaml\n  - c.yaml\n')
+        (tmp_path / 'b.yaml').write_text('includes:\n  - d.yaml\n')
+        (tmp_path / 'c.yaml').write_text('includes:\n  - d.yaml\n')
+        (tmp_path / 'd.yaml').write_text('includes:\n  - c.yaml\n')
+
+        with pytest.raises(cli_exception.CliException) as context:
+            schema_validation.resolve_and_merge_project(tmp_path / 'a.yaml')
+        assert 'Infinite loop' in str(context.value)
+
     def test_rejects_non_yaml_include(self, tmp_path):
         (tmp_path / 'notes.txt').write_text('not a project file')
         entry = tmp_path / 'entry.yaml'

--- a/tests/neoload_cli_lib/test_validator_selection.py
+++ b/tests/neoload_cli_lib/test_validator_selection.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+import neoload_cli_lib.schema_validation as schema_validation
+from neoload_cli_lib import cli_exception
+
+# A minimal schema using "unevaluatedProperties", a Draft 2019-09+ keyword that
+# Draft-07 validators silently ignore (unknown keywords are not an error, just
+# a no-op). Used to prove which draft is actually being applied.
+_BASE_SCHEMA = {
+    "type": "object",
+    "required": ["name"],
+    "allOf": [
+        {"properties": {"name": {"type": "string"}}}
+    ],
+    "unevaluatedProperties": False,
+}
+
+
+def _schema_with(schema_keyword):
+    schema = dict(_BASE_SCHEMA)
+    if schema_keyword is not None:
+        schema = {"$schema": schema_keyword, **schema}
+    return schema
+
+
+@pytest.mark.validation
+class TestValidatorSelection:
+
+    def _validate(self, tmp_path, schema_keyword, project):
+        schema_path = tmp_path / 'schema.json'
+        schema_path.write_text(json.dumps(_schema_with(schema_keyword)))
+        schema_validation.validate_project_object(project, str(schema_path), check_schema=True)
+
+    def test_draft_2019_09_enforces_unevaluated_properties(self, tmp_path):
+        with pytest.raises(cli_exception.CliException):
+            self._validate(tmp_path, "https://json-schema.org/draft/2019-09/schema",
+                            {"name": "ok", "unexpected": "nope"})
+
+    def test_draft_7_ignores_unevaluated_properties(self, tmp_path):
+        # Draft-07 doesn't know "unevaluatedProperties" - it's just an
+        # unrecognized keyword, so an extra property is NOT rejected.
+        self._validate(tmp_path, "http://json-schema.org/draft-07/schema#",
+                        {"name": "ok", "unexpected": "fine-on-draft-07"})
+
+    def test_missing_schema_field_falls_back_to_draft_7(self, tmp_path):
+        # No "$schema" declared at all - falls back to Draft7Validator, same
+        # behaviour as the draft-07 case above.
+        self._validate(tmp_path, None, {"name": "ok", "unexpected": "fine-by-default"})

--- a/tests/neoload_projects/circular_includes/a.yaml
+++ b/tests/neoload_projects/circular_includes/a.yaml
@@ -1,0 +1,3 @@
+name: circular-a
+includes:
+  - b.yaml

--- a/tests/neoload_projects/circular_includes/b.yaml
+++ b/tests/neoload_projects/circular_includes/b.yaml
@@ -1,0 +1,3 @@
+name: circular-b
+includes:
+  - a.yaml

--- a/tests/neoload_projects/invalid_to_schema.yaml
+++ b/tests/neoload_projects/invalid_to_schema.yaml
@@ -1,6 +1,4 @@
 name: NeoLoad-CLI-example-2_0
-includes:
-- paths/geosearch_get.yaml
 
 ifyourelookingforcutthroat:
   singingabumnote:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -123,7 +123,7 @@ class TestReadme:
         assert_success(result_status)
         assert 'settings id: %s' % pytest.test_id in result_status.output
 
-    @pytest.mark.datafiles('tests/neoload_projects/example_1/default.yaml')
+    @pytest.mark.datafiles('tests/neoload_projects/example_1')
     def test_validate(self, datafiles):
         file_path = datafiles / 'default.yaml'
         runner = CliRunner()


### PR DESCRIPTION
- Pick the JSON-Schema validator dynamically from the schema's own declared "$schema" (Draft-07 vs Draft 2019-09+) instead of always using Draft7Validator; fall back to Draft7Validator when no "$schema" is declared.
- Log which validator class is used (DEBUG) to make draft selection visible when troubleshooting.
- Cache the schema's HTTP ETag alongside the cached schema content (new "yaml_schema.etag" file) and send it as "If-None-Match" on subsequent network fetches, so an unchanged remote schema returns 304 Not Modified instead of being fully re-downloaded and re-hashed every time.
- Local file schema sources keep their original hash-comparison behavior (no ETag concept for local paths); network fetch failures still invalidate the schema and raise the existing error, matching prior behavior.
- Clarify log messages around schema loading/caching to reflect whether an ETag was involved (e.g. "Loaded schema and ETag from disk cache.", "Cached schema and ETag updated from remote source.").

## Resolve and merge includes before validation

- Add `resolve_includes()`: recursively resolves `includes:` starting from an entry file, mirroring neoload-legacy's `ConfigurationManager.parseAsCodeFile` (include paths resolved relative to the project root, not the including file's own directory; only yaml/yml/json accepted; infinite-loop detection).
- Add `merge_projects()`: concatenates the array-valued top-level properties (`variables`, `servers`, `sla_profiles`, `populations`, `scenarios`, `user_paths`) and unions `project_settings` across all resolved files - same plain-concatenation semantics as neoload-legacy's `mergeAsCodeProject`.
- `validate_yaml()` now resolves+merges before validating a single file, so missing/unknown fields on the merged project are caught even when they only become complete once includes are pulled in.
- `validate_yaml_dir()` now merges every yaml/yml/json file found under the directory into one project and validates it once, instead of validating each file (including included fragments that were never meant to be a complete project on their own) independently.
- Extract `validate_project_object()` to share the actual jsonschema-validation logic between the single-file and directory code paths.

### Verified

- Confirmed against a real multi-file project (`as-code-full-syntax`, 8 included files): merges to a single in-memory project (17 variables, 4 servers, etc.) and validates with 0 errors.
- Confirmed cycle detection, missing-include, and wrong-extension error paths manually.

### Known follow-up

Several existing pytest fixtures (e.g. `tests/neoload_projects/example_1/default.yaml`) reference includes via relative paths, but `pytest-datafiles` only copies the single named file into the test sandbox - not its sibling directories. Now that includes are actually resolved, those tests fail on "As code file not found" in the sandboxed copy; the feature itself is verified to work correctly against the real files on disk. Test fixtures need to be updated to mark whole directories as datafiles where includes are involved.