### PR TITLE
LOAD-38402 [CheckVU CLI] Handle jar additional parameters in CLI

### DIFF
--- a/neoload/commands/checkvu.py
+++ b/neoload/commands/checkvu.py
@@ -30,8 +30,39 @@ __yaml_extensions = (".yaml", ".yml")
 @click.option('--ssl-cert', default="",
               help="Path to SSL certificate or write False to disable certificate checking. "
                    "Used both for schema validation and the JAR download.")
+@click.option('--controller-overlay',
+              help="Path to a .properties file merged (additively) into conf/controller.properties inside the JAR "
+                   "work directory. Only the keys you set are overridden; everything else from the embedded file "
+                   "is kept. Useful for advanced network tuning (timeouts, TLS, …).",
+              metavar="PATH")
+@click.option('--agent-overlay',
+              help="Path to a .properties file merged (additively) into conf/agent.properties inside the JAR "
+                   "work directory. Advanced: used for Load Generator <-> Controller transport tuning.",
+              metavar="PATH")
+@click.option('--proxy',
+              help="Proxy for the test traffic in host:port format (e.g. myproxy.corp:8080). "
+                   "Applies to both HTTP and HTTPS test traffic. "
+                   "This is NOT used for NLWeb API calls.",
+              metavar="HOST:PORT")
+@click.option('--proxy-user',
+              help="Login for proxy authentication (optional).",
+              metavar="LOGIN")
+@click.option('--proxy-password',
+              help="Password for proxy authentication (optional). "
+                   "The environment variable CHECKVU_PROXY_PASSWORD takes precedence over this flag.",
+              metavar="PASSWORD")
+@click.option('--no-proxy',
+              help="Comma-separated list of hosts that bypass the proxy (e.g. localhost,internal.corp).",
+              metavar="HOST1,HOST2,...")
+@click.option('--keep-work', is_flag=True, default=False,
+              help="Keep the temporary work directory after the JAR exits instead of deleting it. "
+                   "Equivalent to setting CHECKVU_CLI_KEEP_WORK=1. "
+                   "Has no effect when CHECKVU_CLI_WORK_ROOT is already set.")
 @click.argument('project')
-def cli(jar_path, jar_url, java, user_path, schema_url, ssl_cert, project):
+def cli(jar_path, jar_url, java, user_path, schema_url, ssl_cert,
+        controller_overlay, agent_overlay,
+        proxy, proxy_user, proxy_password, no_proxy, keep_work,
+        project):
     """Runs a CheckVU on an as-code PROJECT using the headless CheckVU JAR.
     PROJECT is a path to an as-code yaml file. A single virtual user is executed
     to verify the project runs."""
@@ -46,6 +77,16 @@ def cli(jar_path, jar_url, java, user_path, schema_url, ssl_cert, project):
 
     resolved_jar = checkvu_runner.resolve_jar(jar_path, jar_url, ssl_cert)
 
-    command = checkvu_runner.build_command(java_executable, resolved_jar, project, user_path)
+    command = checkvu_runner.build_command(
+        java_executable, resolved_jar, project,
+        user_path=user_path,
+        controller_overlay=controller_overlay,
+        agent_overlay=agent_overlay,
+        proxy=proxy,
+        proxy_user=proxy_user,
+        proxy_password=proxy_password,
+        no_proxy=no_proxy,
+        keep_work=keep_work,
+    )
     exit_code = checkvu_runner.run_checkvu(command)
     sys.exit(exit_code)

--- a/neoload/neoload_cli_lib/checkvu_runner.py
+++ b/neoload/neoload_cli_lib/checkvu_runner.py
@@ -153,10 +153,27 @@ def download_jar(url, destination, ssl_cert=''):
     return destination
 
 
-def build_command(java, jar, project, user_path=None):
+def build_command(java, jar, project, user_path=None,
+                  controller_overlay=None, agent_overlay=None,
+                  proxy=None, proxy_user=None, proxy_password=None, no_proxy=None,
+                  keep_work=False):
     command = [java, "-jar", jar]
     if user_path:
         command.extend(["--user-path", user_path])
+    if controller_overlay:
+        command.extend(["--controller-overlay", controller_overlay])
+    if agent_overlay:
+        command.extend(["--agent-overlay", agent_overlay])
+    if proxy:
+        command.extend(["--proxy", proxy])
+    if proxy_user:
+        command.extend(["--proxy-user", proxy_user])
+    if proxy_password:
+        command.extend(["--proxy-password", proxy_password])
+    if no_proxy:
+        command.extend(["--no-proxy", no_proxy])
+    if keep_work:
+        command.append("--keep-work")
     command.append(project)
     return command
 

--- a/tests/commands/test_checkvu.py
+++ b/tests/commands/test_checkvu.py
@@ -39,6 +39,40 @@ class TestCheckvuRunner:
         command = checkvu_runner.build_command("java", "checkvu.jar", "p.yaml")
         assert command == ["java", "-jar", "checkvu.jar", "p.yaml"]
 
+    def test_build_command_overlays(self):
+        command = checkvu_runner.build_command(
+            "java", "checkvu.jar", "p.yaml",
+            controller_overlay="/tmp/ctrl.properties",
+            agent_overlay="/tmp/agent.properties",
+        )
+        assert command == [
+            "java", "-jar", "checkvu.jar",
+            "--controller-overlay", "/tmp/ctrl.properties",
+            "--agent-overlay", "/tmp/agent.properties",
+            "p.yaml",
+        ]
+
+    def test_build_command_proxy(self):
+        command = checkvu_runner.build_command(
+            "java", "checkvu.jar", "p.yaml",
+            proxy="proxy.corp:8080",
+            proxy_user="alice",
+            proxy_password="secret",
+            no_proxy="localhost,internal",
+        )
+        assert command == [
+            "java", "-jar", "checkvu.jar",
+            "--proxy", "proxy.corp:8080",
+            "--proxy-user", "alice",
+            "--proxy-password", "secret",
+            "--no-proxy", "localhost,internal",
+            "p.yaml",
+        ]
+
+    def test_build_command_keep_work(self):
+        command = checkvu_runner.build_command("java", "checkvu.jar", "p.yaml", keep_work=True)
+        assert command == ["java", "-jar", "checkvu.jar", "--keep-work", "p.yaml"]
+
     def test_resolve_jar_uses_explicit_path(self, tmp_path):
         jar = tmp_path / "checkvu.jar"
         jar.write_text("x")


### PR DESCRIPTION
Reopens @sboudfor-tricentis 's PR https://github.com/Neotys-Labs/neoload-cli/pull/276 , was automatically closed by github when base branch merged

Initial description : 

What?
Add --controller-overlay, --agent-overlay, --proxy, --proxy-user, --proxy-password, --no-proxy, and --keep-work options to the checkvu command, forwarding them directly to the headless CheckVU JAR.

Why?
Users running CheckVU in corporate or constrained environments need to route test traffic through a proxy and fine-tune low-level network settings (TLS versions, socket timeouts, transport tuning) without touching the JAR internals. Without these flags, the only workaround was to pass a full --controller-overlay or --agent-overlay properties file — but the CLI didn't expose those either, making any network customisation impossible from the Python CLI.

How?
Seven new Click options were added to neoload/commands/checkvu.py and forwarded through build_command in neoload/neoload_cli_lib/checkvu_runner.py as literal JAR flags. No new logic is introduced: the JAR already owns proxy handling and properties merging, including the CHECKVU_PROXY_PASSWORD env-var precedence rule (documented in the --proxy-password help text). The --keep-work option maps to the JAR's existing --keep-work / CHECKVU_CLI_KEEP_WORK=1 mechanism.

Options intentionally not added: --timings (debug only), --tls-protocols, --tls-ciphers, --connect-timeout-ms, --so-timeout-ms (all covered by the overlay files).

Testing
All 19 existing tests pass. Three new unit tests were added to tests/commands/test_checkvu.py:

test_build_command_overlays — verifies --controller-overlay and --agent-overlay are appended correctly
test_build_command_proxy — verifies --proxy, --proxy-user, --proxy-password, --no-proxy full combination
test_build_command_keep_work — verifies the --keep-work flag is appended when set