### PR TITLE
LOAD-39511 - Validate as-code YAML against the matching schemaVersion

### DIFF
--- a/neoload/commands/validate.py
+++ b/neoload/commands/validate.py
@@ -2,11 +2,11 @@ import click
 from neoload_cli_lib import cli_exception
 import neoload_cli_lib.schema_validation as schema_validation
 import os
-from neoload_cli_lib.schema_validation import __default_schema_url
 
 @click.command()
-@click.option('--schema-url', help="The URL (or local path) to the as-code schema. By default, use the one on Github",
-              metavar="URL", default=__default_schema_url, show_default=True)
+@click.option('--schema-url', help="The URL (or local path) to the as-code schema. "
+              "When omitted, download schemas/v<schemaVersion>/as-code.schema.json from neoload-models (v3).",
+              metavar="URL", default=None)
 @click.option('--refresh', is_flag=True, help="THIS OPTION IS NOW USELESS", hidden=True)
 @click.option('--ssl-cert', default="", help="Path to SSL certificate or write False to disable certificate checking")
 @click.argument('file')

--- a/neoload/neoload_cli_lib/schema_validation.py
+++ b/neoload/neoload_cli_lib/schema_validation.py
@@ -16,10 +16,14 @@ import  gitignorefile
 from neoload_cli_lib.neoLoad_project import is_not_to_be_included
 
 YAML_NOT_CONFIRM_MESSAGE = "YAML does not confirm to NeoLoad DSL schema."
-__default_schema_url = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3/neoload-project/src/main/resources/as-code.latest.schema.json"
+__models_raw_root = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3"
+__compatibility_url = __models_raw_root + "/schemas/compatibility.json"
+__default_schema_version = "3.0"
+# Legacy URL kept so explicit --schema-url / NLCLI_FORCE_SCHEMA still work.
+__default_schema_url = __models_raw_root + "/neoload-project/src/main/resources/as-code.latest.schema.json"
 
 _MERGED_ARRAY_FIELDS = ['sla_profiles', 'variables', 'servers', 'user_paths', 'populations', 'scenarios', 'frameworks']
-_MERGED_SPECIAL_FIELDS = set(_MERGED_ARRAY_FIELDS) | {'project_settings', 'name', 'includes'}
+_MERGED_SPECIAL_FIELDS = set(_MERGED_ARRAY_FIELDS) | {'project_settings', 'name', 'includes', 'schemaVersion'}
 
 
 def parse_yaml_file(file_path):
@@ -54,6 +58,10 @@ def merge_projects(projects):
     for project in projects:
         if project.get('name'):
             merged['name'] = project['name']
+
+    for project in projects:
+        if 'schemaVersion' in project and project.get('schemaVersion') is not None:
+            merged['schemaVersion'] = normalize_schema_version(project['schemaVersion'])
 
     # Carry over any other/unrecognized top-level key too, so genuinely
     # invalid content isn't silently dropped by the merge instead of being
@@ -112,8 +120,60 @@ def resolve_and_merge_project(entry_file_path):
     return merge_projects(resolved)
 
 
+def normalize_schema_version(value):
+    """Return the schemaVersion contract as a string. Absent values default to 3.0."""
+    if value is None or value == '':
+        return __default_schema_version
+    if isinstance(value, bool):
+        raise cli_exception.CliException('Invalid schemaVersion: %s' % value)
+    if isinstance(value, int):
+        return '%s.0' % value
+    if isinstance(value, float):
+        if value == int(value):
+            return '%s.0' % int(value)
+        return str(value)
+    return str(value).strip()
+
+
+def schema_url_for_version(version):
+    return '%s/schemas/v%s/as-code.schema.json' % (__models_raw_root, version)
+
+
+def load_supported_schema_versions(ssl_cert=''):
+    """Supported versions are the keys of neoload-models schemas/compatibility.json (v3)."""
+    compatibility_json, _etag, _not_modified = get_network_schema_by_spec(__compatibility_url, ssl_cert)
+    if compatibility_json is None:
+        raise cli_exception.CliException(
+            'Could not load schema compatibility matrix from %s' % __compatibility_url)
+    try:
+        compatibility = json.loads(compatibility_json)
+    except JSONDecodeError as err:
+        raise cli_exception.CliException(
+            'Invalid schema compatibility matrix at %s:\n%s' % (__compatibility_url, err))
+    if not isinstance(compatibility, dict) or not compatibility:
+        raise cli_exception.CliException(
+            'Schema compatibility matrix at %s does not list any versions.' % __compatibility_url)
+    return compatibility
+
+
+def resolve_schema_spec(project_object, schema_spec=None, ssl_cert=''):
+    """Pick the GitHub schema URL from schemaVersion, unless the caller overrode it."""
+    if schema_spec is not None:
+        return schema_spec, None
+    version = normalize_schema_version((project_object or {}).get('schemaVersion'))
+    compatibility = load_supported_schema_versions(ssl_cert)
+    if version not in compatibility:
+        supported = ', '.join(sorted(compatibility.keys()))
+        raise cli_exception.CliException(
+            'Unsupported schemaVersion "%s". Supported versions: %s' % (version, supported))
+    return schema_url_for_version(version), version
+
+
 def validate_project_object(project_object, schema_spec, ssl_cert='', check_schema=True, label=None):
-    json_schema = init_yaml_schema_with_checks(schema_spec,ssl_cert,check_schema)
+    if project_object is not None and 'schemaVersion' in project_object and project_object.get('schemaVersion') is not None:
+        project_object['schemaVersion'] = normalize_schema_version(project_object['schemaVersion'])
+    schema_spec, schema_key = resolve_schema_spec(project_object, schema_spec, ssl_cert)
+    json_schema = init_yaml_schema_with_checks(schema_spec, ssl_cert, check_schema, schema_key=schema_key)
     try:
         schema_as_object = json.loads(json_schema)
     except JSONDecodeError as err:
@@ -207,10 +267,10 @@ def validate_yaml_dir(path, schema_spec, ssl_cert='',continue_on_error=True):
         raise ValueError('One or more errors in files underneath this directory.')
 
 
-def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
-    json_schema = get_yaml_schema(False)
+def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True, schema_key=None):
+    json_schema = get_yaml_schema(False, schema_key=schema_key)
     if json_schema is not None:
-        cached_etag = get_yaml_schema_etag()
+        cached_etag = get_yaml_schema_etag(schema_key=schema_key)
         if cached_etag:
             logging.info('Loaded schema and ETag from disk cache.')
         else:
@@ -222,13 +282,13 @@ def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
     if not check_schema:
         return json_schema
 
-    schema_spec_remote = __default_schema_url
-    if schema_spec is None: schema_spec = schema_spec_remote
+    if schema_spec is None:
+        schema_spec = __default_schema_url
     logging.debug("Checking schema source for changes %s" %schema_spec)
 
     try:
         if is_network_spec(schema_spec):
-            cached_etag = get_yaml_schema_etag() if json_schema is not None else None
+            cached_etag = get_yaml_schema_etag(schema_key=schema_key) if json_schema is not None else None
             json_schema_spec, response_etag, not_modified = get_network_schema_by_spec(schema_spec, ssl_cert, cached_etag)
             if not_modified:
                 logging.info('Remote schema unchanged since last download (ETag match) - using cached schema.')
@@ -239,7 +299,7 @@ def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
                 else:
                     logging.info('Cached schema updated from remote source (no ETag).')
                 json_schema = json_schema_spec
-                update_schema(json_schema_spec, response_etag)
+                update_schema(json_schema_spec, response_etag, schema_key=schema_key)
             else:
                 json_schema = None
         else:
@@ -253,7 +313,7 @@ def init_yaml_schema_with_checks(schema_spec, ssl_cert='', check_schema=True):
             if hash_disk != hash_spec:
                 logging.info('Cached schema differs from source!')
                 json_schema = json_schema_spec
-                update_schema(json_schema_spec)
+                update_schema(json_schema_spec, schema_key=schema_key)
             else:
                 logging.info('No differences between cached and remote schema.')
     except Exception as err:
@@ -307,3 +367,4 @@ def get_json_schema_by_spec(schema_spec, ssl_cert):
             raise bad_as_code_exception.BadAsCodeSchemaException('Could not load schema from provided file spec: %s' % schema_spec)
 
     return json_schema_spec
+

--- a/neoload/neoload_cli_lib/user_data.py
+++ b/neoload/neoload_cli_lib/user_data.py
@@ -18,6 +18,16 @@ CONFIG_FILE = __local_file if os.path.exists(__local_file) else os.path.join(__c
 __yaml_schema_file = os.path.join(__config_dir, "yaml_schema.json")
 __yaml_schema_etag_file = os.path.join(__config_dir, "yaml_schema.etag")
 
+
+def __schema_cache_paths(schema_key=None):
+    if not schema_key:
+        return __yaml_schema_file, __yaml_schema_etag_file
+    safe_key = re.sub(r'[^0-9A-Za-z._-]', '_', str(schema_key))
+    return (
+        os.path.join(__config_dir, "yaml_schema-%s.json" % safe_key),
+        os.path.join(__config_dir, "yaml_schema-%s.etag" % safe_key),
+    )
+
 __no_write = False
 
 
@@ -239,44 +249,64 @@ def get_meta_required(key):
     return get_user_data().metadata.get(key)
 
 
-def __load_yaml_schema():
-    if os.path.exists(__yaml_schema_file):
-        with open(__yaml_schema_file, "r") as stream:
+def __load_yaml_schema(schema_key=None):
+    schema_file, _etag_file = __schema_cache_paths(schema_key)
+    if os.path.exists(schema_file):
+        with open(schema_file, "r") as stream:
             return stream.read()
     return None
 
 
-def __load_yaml_schema_etag():
-    if os.path.exists(__yaml_schema_etag_file):
-        with open(__yaml_schema_etag_file, "r") as stream:
+def __load_yaml_schema_etag(schema_key=None):
+    _schema_file, etag_file = __schema_cache_paths(schema_key)
+    if os.path.exists(etag_file):
+        with open(etag_file, "r") as stream:
             return stream.read() or None
     return None
 
 
 __yaml_schema_singleton = __load_yaml_schema()
 __yaml_schema_etag_singleton = __load_yaml_schema_etag()
+__yaml_schema_by_key = {}
+__yaml_schema_etag_by_key = {}
 
 
-def get_yaml_schema(throw=True):
+def get_yaml_schema(throw=True, schema_key=None):
+    if schema_key:
+        if schema_key not in __yaml_schema_by_key:
+            __yaml_schema_by_key[schema_key] = __load_yaml_schema(schema_key)
+        schema = __yaml_schema_by_key[schema_key]
+        if schema is None and throw:
+            raise cli_exception.CliException("No yaml schema found. Please add --refresh option to download it first")
+        return schema
     if __yaml_schema_singleton is None and throw:
         raise cli_exception.CliException("No yaml schema found. Please add --refresh option to download it first")
     return __yaml_schema_singleton
 
 
-def get_yaml_schema_etag():
+def get_yaml_schema_etag(schema_key=None):
+    if schema_key:
+        if schema_key not in __yaml_schema_etag_by_key:
+            __yaml_schema_etag_by_key[schema_key] = __load_yaml_schema_etag(schema_key)
+        return __yaml_schema_etag_by_key[schema_key]
     return __yaml_schema_etag_singleton
 
 
-def update_schema(yaml_schema_as_json: str, etag: str = None):
+def update_schema(yaml_schema_as_json: str, etag: str = None, schema_key=None):
     global __yaml_schema_singleton, __yaml_schema_etag_singleton
+    schema_file, etag_file = __schema_cache_paths(schema_key)
+    os.makedirs(__config_dir, exist_ok=True)
+    with open(schema_file, "w") as stream:
+        stream.write(yaml_schema_as_json)
+    if etag:
+        with open(etag_file, "w") as stream:
+            stream.write(etag)
+    elif os.path.exists(etag_file):
+        # no etag for this schema source (e.g. a local file) - don't leave a stale one around
+        os.remove(etag_file)
+    if schema_key:
+        __yaml_schema_by_key[schema_key] = yaml_schema_as_json
+        __yaml_schema_etag_by_key[schema_key] = etag
+        return
     __yaml_schema_singleton = yaml_schema_as_json
     __yaml_schema_etag_singleton = etag
-    os.makedirs(__config_dir, exist_ok=True)
-    with open(__yaml_schema_file, "w") as stream:
-        stream.write(__yaml_schema_singleton)
-    if etag:
-        with open(__yaml_schema_etag_file, "w") as stream:
-            stream.write(etag)
-    elif os.path.exists(__yaml_schema_etag_file):
-        # no etag for this schema source (e.g. a local file) - don't leave a stale one around
-        os.remove(__yaml_schema_etag_file)

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 from commands.validate import cli as validate
 from neoload_cli_lib.user_data import __yaml_schema_file as yaml_schema_file
+from neoload_cli_lib.user_data import __schema_cache_paths as schema_cache_paths
 from neoload_cli_lib import user_data
 import neoload_cli_lib.schema_validation as schema_validation
 import os
@@ -134,14 +135,15 @@ class TestValidate:
         try:
             result = self.try_dir_with_schema(datafiles_schema) # start with a known schema
 
-            orig_mtime = os.path.getmtime(l)
+            versioned_schema, _etag = schema_cache_paths('3.0')
+            if os.path.exists(versioned_schema):
+                os.remove(versioned_schema)
+            getattr(user_data, '__yaml_schema_by_key').pop('3.0', None)
+            getattr(user_data, '__yaml_schema_etag_by_key').pop('3.0', None)
             result = self.try_success(datafiles_ascode)
-            now_mtime = os.path.getmtime(l)
-
-            assert orig_mtime != now_mtime, 'The --refresh command did ' + \
-                'not actually update the file on disk! ' + \
-                'orig_mtime: {}, now_mtime: {}\nexit_code: {}\noutput: {}' \
-                    .format(orig_mtime,now_mtime,result.exit_code,result.output)
+            assert os.path.exists(versioned_schema), 'Default schemaVersion 3.0 did ' + \
+                'not write its versioned cache on disk!\nexit_code: {}\noutput: {}' \
+                    .format(result.exit_code, result.output)
         except Exception as err:
             err_msg = "err: {}".format(err)
 

--- a/tests/neoload_cli_lib/test_SchemaValidation.py
+++ b/tests/neoload_cli_lib/test_SchemaValidation.py
@@ -1,6 +1,10 @@
+from unittest import mock
+
+import json
 import pytest
 
 import neoload_cli_lib.schema_validation as schema_validation
+from neoload_cli_lib import cli_exception
 
 
 @pytest.mark.validation
@@ -38,6 +42,76 @@ class TestSchemaValidation:
         assert 'Unable to open file /invalid/yaml/file_path:' in str(context.value)
         assert 'No such file or directory: \'/invalid/yaml/file_path\'' in str(context.value)
         print(context.value)
+
+    def test_absent_schema_version_resolves_v3_0_schema_url(self):
+        spec, key = self._resolve({'name': 'p'})
+        assert spec == schema_validation.schema_url_for_version('3.0')
+        assert key == '3.0'
+
+    def test_schema_version_3_1_resolves_v3_1_schema_url(self):
+        spec, key = self._resolve({'name': 'p', 'schemaVersion': '3.1'})
+        assert spec == schema_validation.schema_url_for_version('3.1')
+        assert key == '3.1'
+
+    def test_numeric_schema_version_is_normalized(self):
+        spec, key = self._resolve({'name': 'p', 'schemaVersion': 3.0})
+        assert spec == schema_validation.schema_url_for_version('3.0')
+        assert key == '3.0'
+
+    def test_unsupported_schema_version_fails_with_dynamic_list(self):
+        with pytest.raises(cli_exception.CliException) as context:
+            self._resolve({'name': 'p', 'schemaVersion': '9.9'})
+        message = str(context.value)
+        assert 'Unsupported schemaVersion "9.9"' in message
+        assert '3.0' in message
+        assert '3.1' in message
+
+    def test_explicit_schema_spec_skips_compatibility_lookup(self):
+        with mock.patch('requests.get') as mock_get:
+            spec, key = schema_validation.resolve_schema_spec(
+                {'name': 'p', 'schemaVersion': '3.1'}, schema_spec='/tmp/custom-schema.json')
+        mock_get.assert_not_called()
+        assert spec == '/tmp/custom-schema.json'
+        assert key is None
+
+    def test_validate_yaml_downloads_schema_for_declared_version(self, tmp_path):
+        yaml_path = tmp_path / 'project.yaml'
+        yaml_path.write_text('name: foo\nschemaVersion: "3.1"\n')
+        schema = json.dumps({
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": False,
+            "properties": {
+                "name": {"type": "string"},
+                "schemaVersion": {"type": "string"},
+            },
+        })
+        requested = []
+
+        def fake_get(url, **kwargs):
+            requested.append(url)
+            response = mock.Mock(status_code=200)
+            response.headers.get.return_value = None
+            if url.endswith('compatibility.json'):
+                response.text = '{"3.0": {}, "3.1": {}}'
+            elif url.endswith('schemas/v3.1/as-code.schema.json'):
+                response.text = schema
+            else:
+                raise AssertionError('unexpected schema URL: %s' % url)
+            return response
+
+        with mock.patch('requests.get', side_effect=fake_get):
+            schema_validation.validate_yaml(str(yaml_path), None)
+
+        assert any(url.endswith('schemas/v3.1/as-code.schema.json') for url in requested)
+
+    def _resolve(self, project):
+        response = mock.Mock(status_code=200, text='{"3.0": {}, "3.1": {}}')
+        response.headers.get.return_value = None
+        with mock.patch('requests.get', return_value=response) as mock_get:
+            spec, key = schema_validation.resolve_schema_spec(project, schema_spec=None)
+        assert 'compatibility.json' in mock_get.call_args.args[0]
+        return spec, key
 
 
 __schema_url__ = "https://raw.githubusercontent.com/Neotys-Labs/neoload-models/v3/neoload-project/src/main/resources/as-code.latest.schema.json"

--- a/tests/neoload_cli_lib/test_include_resolution.py
+++ b/tests/neoload_cli_lib/test_include_resolution.py
@@ -94,6 +94,13 @@ class TestMergeProjects:
         ])
         assert merged['name'] == 'root-project'
 
+    def test_root_schema_version_wins_over_include(self):
+        merged = schema_validation.merge_projects([
+            {'schemaVersion': '3.1'},
+            {'name': 'root-project', 'schemaVersion': '3.0'},
+        ])
+        assert merged['schemaVersion'] == '3.0'
+
     def test_merges_project_settings_across_files(self):
         merged = schema_validation.merge_projects([
             {'project_settings': {'dynatrace.enabled': True}},


### PR DESCRIPTION
## Summary
- Resolve the as-code JSON Schema from `schemaVersion` (default `3.0` when absent) using `neoload-models` `schemas/compatibility.json` on branch `v3`.
- Download `schemas/v{version}/as-code.schema.json` instead of always using `as-code.latest.schema.json`; unsupported versions fail with the dynamic supported list.
- Cache schemas per version so 3.0 and 3.1 do not overwrite each other. `--schema-url` remains an explicit override.

## Test plan
- [ ] `PYTHONPATH=neoload pytest -v -m "not slow" tests/neoload_cli_lib/test_SchemaValidation.py tests/neoload_cli_lib/test_include_resolution.py tests/commands/test_validate.py`
- [ ] `python -m neoload validate tests/neoload_projects/example_1/default.yaml` (no `schemaVersion` → v3.0 schema)
- [ ] Validate a file with `schemaVersion: "3.1"` against `schemas/v3.1/as-code.schema.json`
- [ ] Validate a file with an unknown `schemaVersion` and confirm the error lists versions from `compatibility.json`
- [ ] Confirm `--schema-url` still bypasses version routing


Made with [Cursor](https://cursor.com)